### PR TITLE
Switch the JDK 8 Alpine image to AdoptOpenJDK

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Fabio Kruger
+# Copyright (c) 2019-2020 Fabio Kruger and other contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM openjdk:8-jdk-alpine3.9
+# FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
+# There is no official Alpine images at the moment.
+# Needs upgrade when/if there is an official alpine image.
+FROM adoptopenjdk/openjdk8:jdk8u262-b10-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The image has several supported configurations, which can be accessed via the fo
 
 * `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk`)
 * `jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11-jdk`)
-* `alpine`: Small image based on Alpine Linux (based on `openjdk:8-jdk-alpine`)
+* `alpine`: Small image based on Alpine Linux (based on `adoptopenjdk/openjdk8:jdk8u${version}-alpine`)
 * `jdk8-windowsservercore-1809`: Latest version with the newest remoting (based on `adoptopenjdk:8-jdk-hotspot-windowsservercore-1809`)
 * `jdk11-windowsservercore-1809`: Latest version with the newest remoting and Java 11 (based on `adoptopenjdk:11-jdk-hotspot-windowsservercore-1809`)
 * `jdk8-nanoserver-1809`: Latest version with the newest remoting with Windows Nano Server


### PR DESCRIPTION
Same as https://github.com/jenkinsci/docker/pull/975, bit for the agent. Similar package difference concerns apply, let's discuss them in the controller pull request

- [x] Fix
- [x] Autotests
- [ ] Manual tests?
