### PR TITLE
Hacktoberfest - Add warning about deprecated images and rename images in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkins/ssh-agent.svg)](https://hub.docker.com/r/jenkins/ssh-agent/)
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/docker-ssh-agent.svg?label=changelog)](https://github.com/jenkinsci/docker-ssh-agent/releases)
 
+:exclamation: **Warning!** This image used to be published as [jenkinsci/ssh-slave](https://hub.docker.com/r/jenkinsci/ssh-slave/) and [jenkins/ssh-slave](https://hub.docker.com/r/jenkins/ssh-slave/).
+These images are deprecated, use [jenkins/ssh-agent](https://hub.docker.com/r/jenkins/ssh-agent/).
+
 A [Jenkins](https://jenkins.io) agent image which allows using SSH to establish the connection.
 It can be used together with the [SSH Build Agents plugin](https://plugins.jenkins.io/ssh-slaves) or other similar plugins.
 

--- a/setup-sshd
+++ b/setup-sshd
@@ -25,9 +25,9 @@ set -ex
 #  THE SOFTWARE.
 
 # Usage:
-#  docker run jenkinsci/ssh-slave <public key>
+#  docker run jenkins/ssh-agent <public key>
 # or
-#  docker run -e "JENKINS_AGENT_SSH_PUBKEY=<public key>" jenkinsci/ssh-slave
+#  docker run -e "JENKINS_AGENT_SSH_PUBKEY=<public key>" jenkins/ssh-agent
 
 write_key() {
   local ID_GROUP


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846