### PR TITLE
Only set required environment vars, symlink java to /usr/local/bin

### DIFF
--- a/11/debian/buster/Dockerfile
+++ b/11/debian/buster/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
-RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+RUN echo "export JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
 
 RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
     ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac

--- a/11/debian/buster/Dockerfile
+++ b/11/debian/buster/Dockerfile
@@ -50,6 +50,12 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
+RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+
+RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
+    ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac
+
+
 EXPOSE 22
 
 ENTRYPOINT ["setup-sshd"]

--- a/11/debian/stretch/Dockerfile
+++ b/11/debian/stretch/Dockerfile
@@ -51,6 +51,12 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
+RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+
+RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
+    ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac
+
+
 EXPOSE 22
 
 ENTRYPOINT ["setup-sshd"]

--- a/11/debian/stretch/Dockerfile
+++ b/11/debian/stretch/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
-RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+RUN echo "export JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
 
 RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
     ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -58,6 +58,12 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
+RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+
+RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
+    ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac
+
+
 EXPOSE 22
 
 ENTRYPOINT ["setup-sshd"]

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
-RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+RUN echo "export JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
 
 RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
     ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac

--- a/8/debian/buster/Dockerfile
+++ b/8/debian/buster/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
-RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+RUN echo "export JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
 
 RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
     ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac

--- a/8/debian/buster/Dockerfile
+++ b/8/debian/buster/Dockerfile
@@ -50,6 +50,12 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
+RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+
+RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
+    ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac
+
+
 EXPOSE 22
 
 ENTRYPOINT ["setup-sshd"]

--- a/8/debian/stretch/Dockerfile
+++ b/8/debian/stretch/Dockerfile
@@ -50,6 +50,11 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
+RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+
+RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
+    ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac
+
 EXPOSE 22
 
 ENTRYPOINT ["setup-sshd"]

--- a/8/debian/stretch/Dockerfile
+++ b/8/debian/stretch/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR "${JENKINS_AGENT_HOME}"
 
 COPY setup-sshd /usr/local/bin/setup-sshd
 
-RUN echo -e "JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
+RUN echo "export JAVA_HOME=${JAVA_HOME}\nexport JAVA_VERSION=${JAVA_VERSION}\nexport JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}" >> /etc/environment
 
 RUN ln -s ${JAVA_HOME}/bin/java /usr/local/bin/java && \
     ln -s ${JAVA_HOME}/bin/javac /usr/local/bin/javac

--- a/setup-sshd
+++ b/setup-sshd
@@ -51,7 +51,7 @@ if [[ ${JENKINS_SLAVE_SSH_PUBKEY} == ssh-* ]]; then
 fi
 
 # ensure variables passed to docker container are also exposed to ssh sessions
-env | grep _ >> /etc/environment
+# env | grep _ >> /etc/environment
 
 if [[ $# -gt 0 ]]; then
   echo "${0##*/} params: $@"


### PR DESCRIPTION
This patch will fix #33 by setting only JAVA_HOME and JAVA_VERSION
in the /etc/environment, the PATH problem is solved
by symbolic linking `java` and `javac` binaries to
`/usr/local/bin`, which is always available on PATH

Test suite passes.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
