### PR TITLE
Test to run Java inside an SSH connection

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -56,6 +56,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+RUN echo "export PATH=${PATH}" >> /etc/profile
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

* It adds a test to run Java inside an SSH connection
* It adds the PATH to Java in the /etc/profile on Alpine Docker images.

The test to run Java inside an SSH connection is a simple test that launches an SSH Docker container connects and runs the command `java -version`, if Java is in the path the test would pass. During the process, I've detected the same issue on the Alpine Docker images so I've fixed it.

 
Related to https://github.com/jenkinsci/docker-ssh-agent/pull/74 https://github.com/jenkinsci/docker-ssh-agent/issues/33

CC @timja 