### PR TITLE
fix: run the java check commands as jenkins user

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -65,14 +65,14 @@ function teardown () {
 
   if [[ "${JDK}" -eq 8 ]]
   then
-    run docker exec "${AGENT_CONTAINER}" sh -c "
+    run docker exec -u 1000:1000 "${AGENT_CONTAINER}" sh -c "
     java -version 2>&1 \
       | grep -o -E '^openjdk version \"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*\"' \
       | grep -o -E '\.[[:digit:]]+\.' \
       | grep -o -E '[[:digit:]]+'
     "
   else
-    run docker exec "${AGENT_CONTAINER}" sh -c "
+    run docker exec -u 1000:1000 "${AGENT_CONTAINER}" sh -c "
     java -version 2>&1 \
       | grep -o -E '^openjdk version \"[[:digit:]]+\.' \
       | grep -o -E '\"[[:digit:]]+\.' \


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

There are a couple of tests that checks that Java can run, those tests run with the root user, the user used for the SSH connections is jenkins (1000:1000). To test Java as root user does not seems correct due to root is not the target user.