### PR TITLE
Add jdk8 debian image for the arm64 arch.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,6 +11,7 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk8",
   ]
 }
 
@@ -61,7 +62,7 @@ target "debian_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk8",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk8",
   ]
-  platforms = ["linux/amd64"]
+  platforms = ["linux/amd64", "linux/arm64",]
 }
 
 target "debian_jdk11" {


### PR DESCRIPTION
The `docker` build for `aarch64` (arm64) does work for me on my Raspberry Pi 3B+ running `Armbian 22.05.0-trunk.0004 Focal` with `Linux 5.16.11-bcm2711` without changing anything.

I have just added `jdk8` under the `targets` and `arm64` for the `jdk8` entry. This follows a [discussion](https://community.jenkins.io/t/starting-an-agent-with-docker-on-a-freshly-installed-aarch64-machine/1682/7?u=poddingue) I had with @dduportal on the forum.

I do hope this will also work for your CI/CD pipeline.

It also works for me with `armv7l` machine (Orange Pi Zero running `Armbian 22.02.1`  with `Linux 5.15.25-sunxi`), but I got it was not straightforward to add this arch into your build system.

I [published](https://hub.docker.com/r/gounthar/ssh-agent/tags) the bullseye image for JDK8, JDK11, JDK17 for arm32 and aarch64 if anyone wants to check them out.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
