### PR TITLE
Use git 2.35.3 and git lfs 3.1.4 on Windows

### DIFF
--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.33.1
+ARG GIT_VERSION=2.35.3
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -53,7 +53,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.0.2
+ARG GIT_LFS_VERSION=3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,7 +36,7 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # install git
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,7 +36,7 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # install git
-ARG GIT_VERSION=2.33.1
+ARG GIT_VERSION=2.35.3
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -45,7 +45,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.0.2
+ARG GIT_LFS_VERSION=3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/8/windows/nanoserver-ltsc2019/Dockerfile
+++ b/8/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.33.1
+ARG GIT_VERSION=2.35.3
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/nanoserver-ltsc2019/Dockerfile
+++ b/8/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/nanoserver-ltsc2019/Dockerfile
+++ b/8/windows/nanoserver-ltsc2019/Dockerfile
@@ -53,7 +53,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=2.13.3
+ARG GIT_LFS_VERSION=3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,7 +36,7 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # Install git
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,7 +36,7 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # Install git
-ARG GIT_VERSION=2.33.1
+ARG GIT_VERSION=2.35.3
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -45,7 +45,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.0.2
+ARG GIT_LFS_VERSION=3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test-%: prepare-test
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
 	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18-alpine \
-		sh -c "npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+		sh -c "npm install -g npm@8.7.0 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ test-%: prepare-test
 	set -x
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:16-alpine \
-		sh -c "npm install -g npm@8.7.0 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18-alpine \
+		sh -c "npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test-%: prepare-test
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
 	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:16-alpine \
-		sh -c "npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+		sh -c "npm install -g npm@8.7.0 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -83,7 +83,7 @@ function run_through_ssh {
 
 		echo "*** Running ssh command"
 		run ssh -i "${TMP_PRIV_KEY_FILE}" \
-			-v \
+			-o LogLevel=quiet \
 			-o UserKnownHostsFile=/dev/null \
 			-o StrictHostKeyChecking=no \
 			-l jenkins \

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -71,7 +71,7 @@ function run_through_ssh {
   local agent_container_name="${1}"
   shift 1
   SSH_PORT=$(get_port "${agent_container_name}" 22)
-  echo "*** SSH_PORT is $(SSH_PORT)"
+  echo "*** SSH_PORT is ${SSH_PORT}"
 	if [[ "${SSH_PORT}" = "" ]]; then
 		printMessage "failed to get SSH port"
 		false

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -71,16 +71,19 @@ function run_through_ssh {
   local agent_container_name="${1}"
   shift 1
   SSH_PORT=$(get_port "${agent_container_name}" 22)
+  echo "*** SSH_PORT is $(SSH_PORT)"
 	if [[ "${SSH_PORT}" = "" ]]; then
 		printMessage "failed to get SSH port"
 		false
 	else
 		TMP_PRIV_KEY_FILE=$(mktemp "${BATS_TMPDIR}"/bats_private_ssh_key_XXXXXXX)
+		echo "*** TMP_PRIV_KEY_FILE is ${TMP_PRIV_KEY_FILE}"
 		echo "${PRIVATE_SSH_KEY}" > "${TMP_PRIV_KEY_FILE}" \
 		 	&& chmod 0600 "${TMP_PRIV_KEY_FILE}"
 
+		echo "*** Running ssh command"
 		run ssh -i "${TMP_PRIV_KEY_FILE}" \
-			-o LogLevel=quiet \
+			-vvv \
 			-o UserKnownHostsFile=/dev/null \
 			-o StrictHostKeyChecking=no \
 			-l jenkins \

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -83,7 +83,7 @@ function run_through_ssh {
 
 		echo "*** Running ssh command"
 		run ssh -i "${TMP_PRIV_KEY_FILE}" \
-			-vvv \
+			-v \
 			-o UserKnownHostsFile=/dev/null \
 			-o StrictHostKeyChecking=no \
 			-l jenkins \

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -71,13 +71,11 @@ function run_through_ssh {
   local agent_container_name="${1}"
   shift 1
   SSH_PORT=$(get_port "${agent_container_name}" 22)
-  echo "*** SSH_PORT is ${SSH_PORT}"
 	if [[ "${SSH_PORT}" = "" ]]; then
 		printMessage "failed to get SSH port"
 		false
 	else
 		TMP_PRIV_KEY_FILE=$(mktemp "${BATS_TMPDIR}"/bats_private_ssh_key_XXXXXXX)
-		echo "*** TMP_PRIV_KEY_FILE is ${TMP_PRIV_KEY_FILE}"
 		echo "${PRIVATE_SSH_KEY}" > "${TMP_PRIV_KEY_FILE}" \
 		 	&& chmod 0600 "${TMP_PRIV_KEY_FILE}"
 


### PR DESCRIPTION
## Use git 2.35.3 and git lfs 3.1.4 on Windows

- Updates git lfs on our Windows Docker ssh agent images for CVE-2022-24826. Does not update Linux versions of git lfs because they are not vulnerable to CVE-2022-24826.
- Use git 2.35.3, not 2.33.1 on Windows

### Git 2.35.3

Use git 2.35.3, not 2.33.1 on Windows

https://github.com/git-for-windows/git/releases/tag/v2.35.3.windows.1 fixes usages of `safe.directory` and `%(prefix)` related to:

* https://github.com/git-for-windows/git/security/advisories/GHSA-vw2c-22j4-2fh2 Uncontrolled search for the Git directory in Git for Windows

* https://github.com/git-for-windows/git/security/advisories/GHSA-gf48-x3vr-j5c3 Git for Windows' uninstaller vulnerable to DLL hijacking when run under the SYSTEM user account

### Git LFS 3.1.4

Updates git lfs on our Windows Docker ssh agent images for CVE-2022-24826.  Does not update Linux versions of git lfs because they are not vulnerable to CVE-2022-24826.

https://www.cve.org/CVERecord?id=CVE-2022-24826 reports that

> On Windows, if Git LFS operates on a malicious repository with a `..exe` file as well as a file named `git.exe`, and `git.exe` is not found in PATH, the `..exe` program will be executed, permitting the attacker to execute arbitrary code.

Git LFS 3.1.3 changelog:

https://github.com/git-lfs/git-lfs/blob/032dca8ee69c193208cd050024c27e82e11aef81/CHANGELOG.md

Git LFS 3.1.4 changelog:

https://github.com/git-lfs/git-lfs/releases/tag/v3.1.4

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
