### PR TITLE
Use JDK 11.0.15 on Windows nanoserver, not JDK 11.0.14.1

### DIFF
--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -29,7 +29,7 @@ FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=11.0.14.1+1
+ARG JAVA_VERSION=11.0.15+10
 ARG JAVA_SHA256=3e7da701aa92e441418299714f0ed6db10c3bb1e2db625c35a2c2cd9cc619731
 ARG JAVA_HOME=C:\jdk-${JAVA_VERSION}
 


### PR DESCRIPTION
Eclipse Temurin Windows build of JDK 11.0.15 is now available.

Docker images are not yet available for other images.
