### PR TITLE
feat(alpine-jdk8) switch base image from deprecated adoptopenjdk to eclipse-temurin (adoptium)

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -23,7 +23,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:x86_64-alpine-jdk8u322-b06
+FROM eclipse-temurin:8u322-b06-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -185,10 +185,6 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
 }
 
 @test "[${SUT_IMAGE}] has utf-8 locale" {
-  if [[ "${SUT_IMAGE}" == *"alpine"*  ]]; then
-    run docker run --entrypoint sh --rm "${SUT_IMAGE}" -c '/usr/glibc-compat/bin/locale charmap'
-  else
-    run docker run --entrypoint sh --rm "${SUT_IMAGE}" -c 'locale charmap'
-  fi
+  run docker run --entrypoint sh --rm "${SUT_IMAGE}" -c 'locale charmap'
   assert_equal "${output}" "UTF-8"
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
