### PR TITLE
feat: introduces a new alpine-jdk17 image based on eclipse-temurin:17.0.2_8-jdk-alpine

### DIFF
--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -1,0 +1,70 @@
+# MIT License
+#
+# Copyright (c) 2019-2022 Fabio Kruger and other contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM eclipse-temurin:17.0.2_8-jdk-alpine
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG JENKINS_AGENT_HOME=/home/${user}
+
+ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+
+RUN mkdir -p "${JENKINS_AGENT_HOME}" \
+    && addgroup -g "${gid}" "${group}" \
+# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+    && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
+# Unblock user
+    && passwd -u "${user}"
+
+RUN apk add --no-cache \
+    bash \
+    openssh \
+    git-lfs \
+    netcat-openbsd
+
+# setup SSH server
+RUN sed -i /etc/ssh/sshd_config \
+        -e 's/#PermitRootLogin.*/PermitRootLogin no/' \
+        -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
+        -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
+        -e 's/#LogLevel.*/LogLevel INFO/' \
+    && mkdir /var/run/sshd
+
+VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
+
+RUN echo "export PATH=${PATH}" >> /etc/profile
+COPY setup-sshd /usr/local/bin/setup-sshd
+
+EXPOSE 22
+
+ENTRYPOINT ["setup-sshd"]
+
+LABEL \
+    org.opencontainers.image.vendor="Jenkins project" \
+    org.opencontainers.image.title="Official Jenkins SSH Agent Docker image" \
+    org.opencontainers.image.description="A Jenkins agent image which allows using SSH to establish the connection" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/jenkinsci/docker-ssh-agent" \
+    org.opencontainers.image.licenses="MIT"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,7 @@
 group "linux" {
   targets = [
     "alpine_jdk8",
+    "alpine_jdk17",    
     "debian_jdk8",
     "debian_jdk11",
     "debian_jdk17",
@@ -47,6 +48,17 @@ target "alpine_jdk8" {
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk8": "",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk8",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk8",
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "alpine_jdk17" {
+  dockerfile = "17/alpine/Dockerfile"
+  context = "."
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
   ]
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
This PR is part of #120 : it introduces a new Alpine image for JDK17 built on top of the official `eclipse-temurin:17.0.2_8-jdk-alpine` image.

Please note that it's not the latest JDK17 version, but I kept the same as the bullseye-JDK17 version for now (a subsequent PR with JDK update is expected)

[edit] Depend on #126 because of the failing test helpers