### PR TITLE
fix(bullseye) ensure that locale is correctly set to C.UTF-8 for all cases

### DIFF
--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -60,7 +60,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-ENV LANG C.UTF-8
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -45,7 +45,7 @@ RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y openssh-server git-lfs \
+    && apt-get install --no-install-recommends -y openssh-server git-lfs netcat-traditional \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -23,7 +23,7 @@ RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y openssh-server git-lfs \
+    && apt-get install --no-install-recommends -y openssh-server git-lfs netcat-traditional \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-ENV LANG C.UTF-8
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -40,7 +40,8 @@ RUN mkdir -p "${JENKINS_AGENT_HOME}" \
 RUN apk add --no-cache \
     bash \
     openssh \
-    git-lfs
+    git-lfs \
+    netcat-openbsd
 
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -36,7 +36,7 @@ RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y openssh-server git-lfs\
+    && apt-get install --no-install-recommends -y openssh-server git-lfs netcat-traditional \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -51,7 +51,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-ENV LANG C.UTF-8
+ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ list: check-reqs
 bats:
 	git clone https://github.com/bats-core/bats-core bats ;\
 	cd bats ;\
-	git checkout v1.4.1
+	git checkout v1.7.0
 
 prepare-test: bats check-reqs
 	git submodule update --init --recursive


### PR DESCRIPTION
While working on adding the images #122 and #123 , a bug on the test helpers was failing the new images, because both PRs reached the threshold were the amout of parallel containers in the CI were slowing down the SSH server startup (~2s instead of ~1s).

By fixing the tests, which implied bumping the bats framework to 1.7.0, it appeared that `docker exec`-ing to the bullseye images congratulates the end user with a (not really) nice warning message: `bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)`.

This change is higly probable to come from the upstream Debian bullseye images, not really sure when (does not matter).

This PR fixes the locale configuration, by using the same instrcution as in https://github.com/jenkinsci/docker-agent.

It also embeds a set of fixes to the test framework, tested successfully on #122, to avoid the concurency problem in the future, by using docker healthchecks during the test phase. Please note that I did not added the healthcheck instruction to the Dockerfile as it would be a breaking change for end users with a Docker Engine.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
