### PR TITLE
jenkins/ssh-agent:alpine looking for Java in wrong place

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -30,7 +30,7 @@ ARG JENKINS_AGENT_HOME=/home/${user}
 
 ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}" \
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
     && addgroup -g "${gid}" "${group}" \
 # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
@@ -49,13 +49,16 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
+        -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
-    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
+# Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
+# The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
+# allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)
+RUN echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -54,7 +54,8 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/environment
+RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
+    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/profile
+RUN echo "export PATH=${PATH}" >> /etc/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -30,7 +30,7 @@ ARG JENKINS_AGENT_HOME=/home/${user}
 
 ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}" \
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
     && addgroup -g "${gid}" "${group}" \
 # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
@@ -49,13 +49,16 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
+        -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
-    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
+# Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
+# The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
+# allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)
+RUN echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -54,7 +54,8 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/environment
+RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
+    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/profile
+RUN echo "export PATH=${PATH}" >> /etc/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -30,7 +30,7 @@ ARG JENKINS_AGENT_HOME=/home/${user}
 
 ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}" \
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
     && addgroup -g "${gid}" "${group}" \
 # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
@@ -49,13 +49,16 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
+        -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
-    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
+# Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
+# The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
+# allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)
+RUN echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -54,7 +54,8 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/environment
+RUN mkdir -p ${JENKINS_AGENT_HOME}/.ssh/ && echo "PATH=${PATH}" >> ${JENKINS_AGENT_HOME}/.ssh/environment && \
+    printf "\nPermitUserEnvironment yes" >> /etc/ssh/sshd_config
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -i /etc/ssh/sshd_config \
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
-RUN echo "export PATH=${PATH}" >> /etc/profile
+RUN echo "export PATH=${PATH}" >> /etc/environment
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM eclipse-temurin:8u332-b09-jdk-focal AS jre-build
 
-FROM debian:bullseye-20220509
+FROM debian:bullseye-20220527
 
 ARG user=jenkins
 ARG group=jenkins

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -101,12 +101,7 @@ docker_run_opts=('--detach' '--publish-all' '--health-cmd=echo | nc -w1 localhos
 
   is_agent_container_running "${test_container_name}"
 
-  if [[ "${SUT_IMAGE}" == *"alpine"*  ]]
-  then
-    run_through_ssh "${test_container_name}" "/bin/bash --login -c 'java -version'"
-  else
-    run_through_ssh "${test_container_name}" java -version
-  fi
+  run_through_ssh "${test_container_name}" java -version
   assert_success
   assert_output --regexp '^openjdk version \"[[:digit:]]+'
 


### PR DESCRIPTION
fixes #127

ssh doesn't source `/etc/profile`, so we have to add the java executable path to `PATH` within the `/etc/environment` file so that `ssh` sources it.
Thanks to @AdamZWinter for spotting that bug and to @dduportal for pointing that fix out.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
