### PR TITLE
Use latest Eclipse Temurin JDKs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
 - package-ecosystem: docker
+  directory: "/11/alpine"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
   directory: "/11/bullseye"
   schedule:
     interval: weekly
@@ -16,17 +21,12 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: docker
-  directory: "/8/alpine"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
-  directory: "/11/alpine"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
   directory: "/17/alpine"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/8/alpine"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: docker
+  directory: "/17/bullseye"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
   directory: "/8/alpine"
   schedule:
     interval: weekly

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:11.0.14.1_1-jdk-alpine
+FROM eclipse-temurin:11.0.16_8-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:11.0.14.1_1-jdk-focal AS jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-focal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:17.0.2_8-jdk-alpine
+FROM eclipse-temurin:17.0.4_8-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -9,7 +9,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye
+FROM debian:bullseye-20220801
 
 ARG user=jenkins
 ARG group=jenkins

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.2_8-jdk-focal AS jre-build
+FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:8u332-b09-jdk-alpine
+FROM eclipse-temurin:8u342-b07-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:8u332-b09-jdk-focal AS jre-build
+FROM eclipse-temurin:8u342-b07-jdk-focal AS jre-build
 
 FROM debian:bullseye-20220801
 


### PR DESCRIPTION
## Use latest Eclipse Temurin JDKs

Update the bundled JDK versions to the most recent Temurin releases

- Use JDK 11.0.16 instead of JDK 11.0.14
- Use JDK 17.0.4 instead of 17.0.2
- Use JDK 8u342 instead of JDK 8u332

Improve dependabot configuration in hopes it will detect these changes automatically.

- Group dependabot entries alphabetically
- Add dependabot for JDK 17 on Debian

Make the JDK 17 Dockerfile more consistent with the JDK 11 and JDK 8 files.

- Use specific Debian version for Java 17 agent

No problem if this combination of commits needs to be split into multiple pull requests.  Just let me know.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
