### PR TITLE
Use JDK 11.0.16 on Windows nanoserver, not 11.0.15

### DIFF
--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -29,8 +29,8 @@ FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=11.0.15+10
-ARG JAVA_SHA256=3e7da701aa92e441418299714f0ed6db10c3bb1e2db625c35a2c2cd9cc619731
+ARG JAVA_VERSION=11.0.16+8
+ARG JAVA_SHA256=446196723c29ac6209c53b662fa73f1f555a01c08d75ef5b9155b0c29f8a82f1
 ARG JAVA_HOME=C:\jdk-${JAVA_VERSION}
 
 USER ContainerAdministrator


### PR DESCRIPTION
## Use JDK 11.0.16 on Windows nanoserver, not 11.0.15

Separately managed JDK version in order to keep the nanoserver image small.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
