### PR TITLE
Use JDK 17.0.4.1 instead of JDK 17.0.4

### DIFF
--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:17.0.4_8-jdk-alpine
+FROM eclipse-temurin:17.0.4.1_1-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility


### PR DESCRIPTION
## Use JDK 17.0.4.1 instead of JDK 17.0.4

From https://www.jenkins.io/doc/upgrade-guide/2.346/#upgrading-to-jenkins-lts-2-346-3

## OpenJDK 11.0.16/17.0.4 and the C2 JIT compiler

OpenJDK 11.0.16 and 17.0.4 are susceptible to JDK-8292260, a regression in
the C2 JIT compiler which may cause the JVM to crash unpredictably. The
OpenJDK project has released fixes in 11.0.16.1 and 17.0.4.1.

## OpenJDK 11.0.16/17.0.4 and the metaspace

The version of OpenJDK in the official Docker image has been upgraded from
11.0.15 to 11.0.16 and from 17.0.3 to 17.0.4. This exposes a metaspace
memory leak in Pipeline: Groovy 2692.v76b_089ccd026 and earlier and in
Script Security 1172.v35f6a_0b_8207e and earlier. After upgrading Jenkins
to 2.346.3, upgrade Pipeline: Groovy to 2705.v0449852ee36f or later and
upgrade Script Security to 1175.v4b_d517d6db_f0 or later. It is generally
recommended to upgrade all plugins after upgrading Jenkins core.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
