### PR TITLE
chore(release-drafter) Allow manual trigger of the release drafter workflow to update changelogs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
When a label was forgotten on a PR, we want to update the "next" draft changelog before releasing.