### PR TITLE
chore(linux) Add `less` and `patch` packages explicitly and a test to validate the installation

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -40,8 +40,10 @@ RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
 RUN apk add --no-cache \
     bash \
     git-lfs \
+    less \
     netcat-openbsd \
-    openssh
+    openssh \
+    patch
 
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -47,8 +47,10 @@ RUN groupadd -g ${gid} ${group} \
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
        git-lfs \
+       less \
        netcat-traditional \
        openssh-server \
+       patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -40,8 +40,10 @@ RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
 RUN apk add --no-cache \
     bash \
     git-lfs \
+    less \
     netcat-openbsd \
-    openssh
+    openssh \
+    patch
     
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -25,8 +25,10 @@ RUN groupadd -g ${gid} ${group} \
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
        git-lfs \
+       less \
        netcat-traditional \
        openssh-server \
+       patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -40,8 +40,10 @@ RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
 RUN apk add --no-cache \
     bash \
     git-lfs \
+    less \
     netcat-openbsd \
-    openssh
+    openssh \
+    patch
     
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -37,9 +37,11 @@ RUN groupadd -g ${gid} ${group} \
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-       git-lfs  \
+       git-lfs \
+       less \
        netcat-traditional \
        openssh-server \
+       patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -189,7 +189,7 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
 }
 
 
-@test "[${SUT_IMAGE}] image has git and SSH client installed and present in the PATH" {
+@test "[${SUT_IMAGE}] image has required tools installed and present in the PATH" {
   local test_container_name=${AGENT_CONTAINER}-bash-java
   clean_test_container "${test_container_name}"
   docker run --name="${test_container_name}" --name="${test_container_name}" "${docker_run_opts[@]}" "${PUBLIC_SSH_KEY}"
@@ -202,6 +202,15 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
   run docker exec "${test_container_name}" sh -c "command -v git"
   assert_success
   run docker exec "${test_container_name}" git --version
+  assert_success
+
+  run docker exec "${test_container_name}" sh -c "command -v less"
+  assert_success
+  run docker exec "${test_container_name}" less -V
+  assert_success
+  run docker exec "${test_container_name}" sh -c "command -v patch"
+  assert_success
+  run docker exec "${test_container_name}" patch --version
   assert_success
 
   clean_test_container "${test_container_name}"


### PR DESCRIPTION
Following PRs #173 and #179, with the help of @dduportal I added the minimal list of packages that are needed to be able to interact with a `git` server (committing, patching, ...) for the various `Debian` and `Alpine` images.

### Current situation

The list of packages brought by installing git-lfs is:

```bash
apt depends git-lfs
git-lfs
  Depends: git
  Depends: libc6 (>= 2.4)

``` 

The list of packages brought by installing git is:

```bash
apt depends git
git
  Depends: libc6 (>= 2.28)
  Depends: libcurl3-gnutls (>= 7.56.1)
  Depends: libexpat1 (>= 2.0.1)
  Depends: libpcre2-8-0 (>= 10.22)
  Depends: zlib1g (>= 1:1.2.0)
  Depends: perl
  Depends: liberror-perl
  Depends: git-man (>> 1:2.30.2)
  Depends: git-man (<< 1:2.30.2-.)
  Recommends: ca-certificates
  Recommends: patch
  Recommends: less
  Recommends: <ssh-client>
    openssh-client
  Suggests: gettext-base
  Suggests: git-daemon-run
  Suggests: git-daemon-sysvinit
  Suggests: git-doc
  Suggests: git-el
  Suggests: git-email
  Suggests: git-gui
  Suggests: gitk
  Suggests: gitweb
  Suggests: git-cvs
  Suggests: git-mediawiki
  Suggests: git-svn
  Replaces: <git-core> (<< 1:1.7.0.4-1.)
  Replaces: gitweb (<< 1:1.7.4~rc1)
```

We're missing `patch` and `less`. Let's check with the current `Debian` image:

```bash
apt update
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8184 kB]
Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [204 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.6 kB]
Fetched 8610 kB in 3s (2811 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
4 packages can be upgraded. Run 'apt list --upgradable' to see them.
root@c4b9bbf5565c:/home/jenkins# less
bash: less: command not found
root@c4b9bbf5565c:/home/jenkins# patch
bash: patch: command not found
``` 

### What should be added

```bash
less patch 
```

### Tests

We added [tests](https://github.com/jenkinsci/docker-ssh-agent/pull/181/files#diff-1059443e6c79adcf296eee8ff7fd5b3fade119e5971104d18119cce68068f959R207) that try to find the `less` and `patch` binaries thanks to `command -v` and then launch the commands to get a `0` return code.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
