### PR TITLE
fix(linux) correct default agent workdir permissions

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -41,7 +41,7 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh" "${JENKINS_AGENT_HOME}/.jenkins" "${AGENT_WORKDIR}"  \
     # Make sure that user 'jenkins' own these directories and their content
     && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -41,8 +41,9 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apk add --no-cache \
     bash \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -26,16 +26,23 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
+
 ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
 
 RUN apk add --no-cache \
     bash \
@@ -52,12 +59,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
-    && mkdir /var/run/sshd
+    && mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -49,17 +49,18 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-       git-lfs \
-       less \
-       netcat-traditional \
-       openssh-server \
-       patch \
+        git-lfs \
+        less \
+        netcat-traditional \
+        openssh-server \
+        patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -26,10 +26,10 @@ FROM eclipse-temurin:11.0.16.1_1-jdk-focal as jre-build
 # for now we include the full module path to maintain compatibility
 # while still saving space
 RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --compress=2 \
+        --output /javaruntime
 
 FROM debian:bullseye-20221114
 
@@ -37,12 +37,21 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
-ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
+
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -60,12 +69,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
-    mkdir /var/run/sshd
+    mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -26,16 +26,24 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
+
 ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+
 
 RUN apk add --no-cache \
     bash \
@@ -44,7 +52,7 @@ RUN apk add --no-cache \
     netcat-openbsd \
     openssh \
     patch
-    
+
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PermitRootLogin.*/PermitRootLogin no/' \
@@ -52,12 +60,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
-    && mkdir /var/run/sshd
+    && mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -41,7 +41,7 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh" "${JENKINS_AGENT_HOME}/.jenkins" "${AGENT_WORKDIR}"  \
     # Make sure that user 'jenkins' own these directories and their content
     && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -41,8 +41,9 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 
 RUN apk add --no-cache \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -27,7 +27,7 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh" "${JENKINS_AGENT_HOME}/.jenkins" "${AGENT_WORKDIR}"  \
     # Make sure that user 'jenkins' own these directories and their content
     && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM eclipse-temurin:17.0.4.1_1-jdk-focal as jre-build
 # for now we include the full module path to maintain compatibility
 # while still saving space
 RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --compress=2 \
+        --output /javaruntime
 
 FROM debian:bullseye-20221114
 
@@ -15,20 +15,29 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
-ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
+
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-       git-lfs \
-       less \
-       netcat-traditional \
-       openssh-server \
-       patch \
+        git-lfs \
+        less \
+        netcat-traditional \
+        openssh-server \
+        patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server
@@ -38,12 +47,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
-    mkdir /var/run/sshd
+    mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -27,8 +27,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 
 RUN apt-get update \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -41,7 +41,7 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh" "${JENKINS_AGENT_HOME}/.jenkins" "${AGENT_WORKDIR}"  \
     # Make sure that user 'jenkins' own these directories and their content
     && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -26,16 +26,23 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
+
 ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
 
 RUN apk add --no-cache \
     bash \
@@ -44,7 +51,7 @@ RUN apk add --no-cache \
     netcat-openbsd \
     openssh \
     patch
-    
+
 # setup SSH server
 RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PermitRootLogin.*/PermitRootLogin no/' \
@@ -52,12 +59,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
-    && mkdir /var/run/sshd
+    && mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -41,8 +41,9 @@ RUN addgroup -g "${gid}" "${group}" \
     # Unblock user
     && passwd -u "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apk add --no-cache \
     bash \

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -28,20 +28,28 @@ ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
-ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ARG JENKINS_AGENT_HOME=/home/${user}
+# Persist through an environment variable for people extending the image
+ENV JENKINS_AGENT_HOME "${JENKINS_AGENT_HOME}"
+
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}/agent"
+# Persist through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-       git-lfs \
-       less \
-       netcat-traditional \
-       openssh-server \
-       patch \
+        git-lfs \
+        less \
+        netcat-traditional \
+        openssh-server \
+        patch \
     && rm -rf /var/lib/apt/lists/*
 
 # setup SSH server
@@ -51,12 +59,10 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PasswordAuthentication.*/PasswordAuthentication no/' \
         -e 's/#SyslogFacility.*/SyslogFacility AUTH/' \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
-    mkdir /var/run/sshd
+    mkdir -p /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+# VOLUME directive must happen after setting up permissions and content
+VOLUME ["${AGENT_WORKDIR}", "${JENKINS_AGENT_HOME}/.jenkins", "/tmp", "/run", "/var/run"]
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -40,8 +40,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins" \
-    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}" "${JENKINS_AGENT_HOME}/.jenkins"
+    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -40,7 +40,7 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
     # Prepare subdirectories
-    && mkdir -p "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}" \
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh" "${JENKINS_AGENT_HOME}/.jenkins" "${AGENT_WORKDIR}"  \
     # Make sure that user 'jenkins' own these directories and their content
     && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -188,6 +188,10 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
   assert_equal "${output}" "UTF-8"
 }
 
+@test "[${SUT_IMAGE}] the default 'jenkins' user is allowed to write in the default agent directory" {
+  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch /home/jenkins/agent/test.txt
+  assert_success
+}
 
 @test "[${SUT_IMAGE}] image has required tools installed and present in the PATH" {
   local test_container_name=${AGENT_CONTAINER}-bash-java


### PR DESCRIPTION
Fixes #182

Fixup of #165 . While working on #165 , I asked @gounthar to add the `AGENT_WORKDIR` to the list of volume but I forgot to add it to the `mkdir + chown` list.


It resulting in Docker creating the non-existing folder when mounting the volume, with root as owner. 

This PR fixes this problem and also exposes the environment variables `JENKINS_AGENT_HOME` and `AGENT_WORKDIR` to users extending this image.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
