### PR TITLE
fix(docker) Change the permissions on the newly declared volumes

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -28,14 +28,21 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
+
 
 RUN apk add --no-cache \
     bash \
@@ -54,14 +61,7 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" \
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -57,11 +57,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" \
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -60,6 +60,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
 # allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -65,12 +65,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
 RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
     chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -69,7 +69,8 @@ VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/r
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -39,10 +39,17 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -62,21 +69,14 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
     mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN echo "PATH=${PATH}" >> /etc/environment

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -68,6 +68,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -57,12 +57,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
 RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
     chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -61,7 +61,8 @@ VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/r
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -28,14 +28,21 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
+
 
 RUN apk add --no-cache \
     bash \
@@ -54,14 +61,7 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -60,6 +60,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
 # allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -46,6 +46,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -43,11 +43,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -17,10 +17,17 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -40,21 +47,14 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
     mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN echo "PATH=${PATH}" >> /etc/environment

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -57,11 +57,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -28,14 +28,21 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
 
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" \
-    && addgroup -g "${gid}" "${group}" \
-# Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+
+RUN addgroup -g "${gid}" "${group}" \
+    # Set the home directory (h), set user and group id (u, G), set the shell, don't ask for password (D)
     && adduser -h "${JENKINS_AGENT_HOME}" -u "${uid}" -G "${group}" -s /bin/bash -D "${user}" \
-# Unblock user
-    && passwd -u "${user}"
+    # Unblock user
+    && passwd -u "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" \
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
+
 
 RUN apk add --no-cache \
     bash \
@@ -54,14 +61,7 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#PermitUserEnvironment.*/PermitUserEnvironment yes/' \
     && mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -60,6 +60,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 # Alpine's ssh doesn't use $PATH defined in /etc/environment, so we define `$PATH` in `~/.ssh/environment`
 # The file path has been created earlier in the file by `mkdir -p` and we also have configured sshd so that it will
 # allow environment variables to be sourced (see `sed` command related to `PermitUserEnvironment`)

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -56,12 +56,13 @@ RUN sed -i /etc/ssh/sshd_config \
 ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
 # Persist agent workdir path through an environment variable for people extending the image
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
-WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
 RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
     chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
+VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -59,6 +59,9 @@ ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
+# The new volumes have to be owned by the jenkins user
+RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -66,6 +69,7 @@ ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
 
 RUN echo "PATH=${PATH}" >> /etc/environment
+
 COPY setup-sshd /usr/local/bin/setup-sshd
 
 EXPOSE 22

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -60,7 +60,8 @@ VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/r
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 # The new volumes have to be owned by the jenkins user
-RUN chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
+RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
+    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -30,10 +30,17 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+ENV JENKINS_AGENT_HOME=${JENKINS_AGENT_HOME}
+ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
+# Persist agent workdir path through an environment variable for people extending the image
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+    && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}" \
+    # Prepare subdirectories
+    && mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}/.jenkins" \
+    # Make sure that user 'jenkins' own these directories and their content
+    && chown -R "${uid}":"${gid}" "${JENKINS_AGENT_HOME}" "${AGENT_WORKDIR}"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -53,21 +60,14 @@ RUN sed -i /etc/ssh/sshd_config \
         -e 's/#LogLevel.*/LogLevel INFO/' && \
     mkdir /var/run/sshd
 
-ARG AGENT_WORKDIR="${JENKINS_AGENT_HOME}"/agent
-# Persist agent workdir path through an environment variable for people extending the image
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-
-# The new volumes have to be owned by the jenkins user
-RUN mkdir -p "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}" && \
-    chown -R "${user}":"${group}" "${JENKINS_AGENT_HOME}/.ssh/" "${JENKINS_AGENT_HOME}/.jenkins/" "${AGENT_WORKDIR}"
-
+# VOLUME directive must happen after setting up permissions and content
 VOLUME "${AGENT_WORKDIR}" "${JENKINS_AGENT_HOME}"/.jenkins "/tmp" "/run" "/var/run"
 WORKDIR "${JENKINS_AGENT_HOME}"
 
 ENV LANG='C.UTF-8' LC_ALL='C.UTF-8'
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
 
 RUN echo "PATH=${PATH}" >> /etc/environment

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -189,7 +189,7 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
 }
 
 @test "[${SUT_IMAGE}] the default 'jenkins' user is allowed to write in the default agent directory" {
-  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch "${AGENT_WORKDIR}"/test.txt
+  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch /home/jenkins/agent/test.txt
   assert_success
 }
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -188,6 +188,10 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
   assert_equal "${output}" "UTF-8"
 }
 
+@test "[${SUT_IMAGE}] the default 'jenkins' user is allowed to write in the default agent directory" {
+  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch /home/jenkins/agent/test.txt
+  assert_success
+}
 
 @test "[${SUT_IMAGE}] image has required tools installed and present in the PATH" {
   local test_container_name=${AGENT_CONTAINER}-bash-java

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -189,7 +189,7 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
 }
 
 @test "[${SUT_IMAGE}] the default 'jenkins' user is allowed to write in the default agent directory" {
-  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch /home/jenkins/agent/test.txt
+  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch "${AGENT_WORKDIR}"/test.txt
   assert_success
 }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Lately, we have changed the volumes (see #165 ).
Unfortunately, this had consequences of not being able to write the `remote.jar` file in the `agent` directory (see #182 ).

Some parts of this PR are directly inspired by/taken from #183.

I created the directories before the `VOLUME` directive and changed their permissions.
This PR also exposes the environment variables `JENKINS_AGENT_HOME` and `AGENT_WORKDIR` to users extending this image.
Let me know if that muddies the water for this PR's goal, or if I should keep it too.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
