### PR TITLE
chore(test) Uses `"${AGENT_WORKDIR}"` instead of hardcoded path.

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -189,7 +189,7 @@ DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
 }
 
 @test "[${SUT_IMAGE}] the default 'jenkins' user is allowed to write in the default agent directory" {
-  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" touch /home/jenkins/agent/test.txt
+  run docker run --user=jenkins --entrypoint='' --rm "${SUT_IMAGE}" sh -c 'touch "${AGENT_WORKDIR}"/test.txt'
   assert_success
 }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Following #184 and [my comment](https://github.com/jenkinsci/docker-ssh-agent/pull/184#issuecomment-1327311142) regarding the fact I wanted to get rid of the hardcoded path, I propose this fix for the test, so that it works even when/if we change the value of the agent workdir one day.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
