### PR TITLE
feat: bump JDK11 to 11.0.17, JDK17 to 17.0.5 and OS base images

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:11.0.16.1_1-jdk-alpine
+FROM eclipse-temurin:11.0.17_8-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:11.0.16.1_1-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.17_8-jdk-focal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -29,8 +29,8 @@ FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=11.0.16.1+1
-ARG JAVA_SHA256=446196723c29ac6209c53b662fa73f1f555a01c08d75ef5b9155b0c29f8a82f1
+ARG JAVA_VERSION=11.0.17+8
+ARG JAVA_SHA256=f051bc3ff84074fd1e7b672c1edfe61327381851e96cd8b6f50dc8dd6f435e8e
 ARG JAVA_HOME=C:\jdk-${JAVA_VERSION}
 
 USER ContainerAdministrator

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM eclipse-temurin:17.0.4.1_1-jdk-alpine
+FROM eclipse-temurin:17.0.5_8-jdk-alpine
 
 ARG user=jenkins
 ARG group=jenkins

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4.1_1-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.5_8-jdk-focal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -65,6 +65,7 @@ target "alpine_jdk11" {
   context = "."
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk11": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk11",
   ]


### PR DESCRIPTION
## Update Java to 11.0.17 and 17.0., and update base images

- Use Java 11.0.17 on Alpine, Bullseye, and Nanoserver
- Use JDK 17.0.5 on Alpine and Bullseye
- Update the alpine label to match alpine-jdk11

https://github.com/jenkins-infra/jenkins.io/issues/5839 is also fixed by this pull request.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue