### PR TITLE
feat(windows) bump git to 2.39.1 patch 1

### DIFF
--- a/11/windows/nanoserver-ltsc2019/Dockerfile
+++ b/11/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,8 +44,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.37.2
-ARG GIT_PATCH_VERSION=2
+ARG GIT_VERSION=2.39.1
+ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,8 +36,8 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # install git
-ARG GIT_VERSION=2.37.2
-ARG GIT_PATCH_VERSION=2
+ARG GIT_VERSION=2.39.1
+ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/8/windows/nanoserver-ltsc2019/Dockerfile
+++ b/8/windows/nanoserver-ltsc2019/Dockerfile
@@ -44,8 +44,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG GIT_VERSION=2.37.2
-ARG GIT_PATCH_VERSION=2
+ARG GIT_VERSION=2.39.1
+ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -36,8 +36,8 @@ ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 USER ContainerAdministrator
 
 # Install git
-ARG GIT_VERSION=2.37.2
-ARG GIT_PATCH_VERSION=2
+ARG GIT_VERSION=2.39.1
+ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
     Write-Host "Retrieving $url..." ; `


### PR DESCRIPTION
Twin of https://github.com/jenkinsci/docker-agent/pull/369

This PR updates (manually) the Git version in the 4 Windows images to 2.39.1 (patch 1) - https://github.com/git-for-windows/git/releases/tag/v2.39.1.windows.1.

Please note that updatecli should manage this in the near future: the tricky part is to capture and handle the patch, but that should be doable.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
