### PR TITLE
chore(updatecli): Now tracks the JDK versions.

### DIFF
--- a/updatecli/updatecli.d/temurin.yaml
+++ b/updatecli/updatecli.d/temurin.yaml
@@ -1,0 +1,104 @@
+---
+name: Bump Temurin's JDK17 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Temurin JDK17 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin17-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
+        # jdk-17.0.4.1+1(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.4.1%2B1) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+      - replacer:
+          from: +
+          to: _
+
+conditions:
+  checkTemurinAlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-alpine'
+  checkTemurinDebianDockerImages:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-jammy" is available
+    disablesourceinput: true
+    spec:
+      architectures:
+        - amd64
+        - arm64
+        - s390x
+        - arm/v7
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-jammy'
+  checkTemurinWindowsCoreDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
+
+targets:
+  setJDK17VersionDockerBake:
+    name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
+    kind: file
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"JAVA17_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+    scmid: default
+  setJDK17VersionAlpine:
+    name: "Bump JDK17 default ARG version on Alpine Dockerfile"
+    kind: dockerfile
+    spec:
+      file: alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK17VersionDebian:
+    name: "Bump JDK17 default ARG version on Debian Dockerfile"
+    kind: dockerfile
+    spec:
+      file: debian/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK17 version to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk17

--- a/updatecli/updatecli.d/temurin.yaml
+++ b/updatecli/updatecli.d/temurin.yaml
@@ -14,7 +14,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  lastVersion:
+  jdk17LastVersion:
     kind: githubrelease
     name: Get the latest Temurin JDK17 version
     spec:
@@ -32,19 +32,36 @@ sources:
       - replacer:
           from: +
           to: _
+  jdk11LastVersion:
+    kind: githubrelease
+    name: Get the latest Temurin JDK11 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin11-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-11.0.4.1+1(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.4.1%2B1) is OK
+        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+      - replacer:
+          from: +
+          to: _
 
 conditions:
-  checkTemurinAlpineDockerImage:
+  checkTemurinJDK17AlpineDockerImage:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available
+    name: Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-alpine" is available
     disablesourceinput: true
     spec:
       architecture: amd64
       image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-alpine'
-  checkTemurinDebianDockerImages:
+      tag: '{{source "jdk17LastVersion" }}-jdk-alpine'
+  checkTemurinJDK17DebianDockerImages:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    name: Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-focal" is available
     disablesourceinput: true
     spec:
       architectures:
@@ -53,30 +70,61 @@ conditions:
         - s390x
         - arm/v7
       image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinWindowsCoreDockerImage:
+      tag: '{{source "jdk17LastVersion" }}-jdk-focal'
+  checkTemurinJDK17WindowsCoreDockerImage:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    name: Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-windowsservercore-1809" is available
     disablesourceinput: true
     spec:
       architecture: amd64
       image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
+      tag: '{{source "jdk17LastVersion" }}-jdk-windowsservercore-1809'
 
+  checkTemurinJDK11AlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-alpine" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-alpine'
+  checkTemurinJDK11DebianDockerImages:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architectures:
+        - amd64
+        - arm64
+        - s390x
+        - arm/v7
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-focal'
+  checkTemurinJDK11WindowsCoreDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-windowsservercore-1809" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-windowsservercore-1809'
+      
 targets:
   setJDK17VersionDockerBake:
     name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
     kind: file
+    sourceid: jdk17LastVersion
     spec:
       file: docker-bake.hcl
       matchpattern: >-
         variable(.*)"JAVA17_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
       replacepattern: >-
-        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "jdk17LastVersion" }}"
     scmid: default
   setJDK17VersionAlpine:
     name: "Bump JDK17 default ARG version on Alpine Dockerfile"
     kind: dockerfile
+    sourceid: jdk17LastVersion
     spec:
       file: alpine/Dockerfile
       instruction:
@@ -86,18 +134,29 @@ targets:
   setJDK17VersionDebian:
     name: "Bump JDK17 default ARG version on Debian Dockerfile"
     kind: dockerfile
+    sourceid: jdk17LastVersion
     spec:
       file: debian/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-
+  setJDK11VersionDockerBake:
+    name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
+    kind: file
+    sourceid: jdk11LastVersion
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"JAVA11_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"JAVA11_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "jdk11LastVersion" }}"
+    scmid: default
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK17 version to {{ source "lastVersion" }}
+    title: Bump JDK17 version to {{ source "jdk17LastVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/temurin.yaml
+++ b/updatecli/updatecli.d/temurin.yaml
@@ -44,7 +44,7 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk-alpine'
   checkTemurinDebianDockerImages:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-jammy" is available
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
     disablesourceinput: true
     spec:
       architectures:
@@ -53,7 +53,7 @@ conditions:
         - s390x
         - arm/v7
       image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-jammy'
+      tag: '{{source "lastVersion" }}-jdk-focal'
   checkTemurinWindowsCoreDockerImage:
     kind: dockerimage
     name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available

--- a/updatecli/updatecli.d/temurin.yaml
+++ b/updatecli/updatecli.d/temurin.yaml
@@ -79,7 +79,6 @@ conditions:
       architecture: amd64
       image: eclipse-temurin
       tag: '{{source "jdk17LastVersion" }}-jdk-windowsservercore-1809'
-
   checkTemurinJDK11AlpineDockerImage:
     kind: dockerimage
     name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-alpine" is available
@@ -137,6 +136,26 @@ targets:
     sourceid: jdk17LastVersion
     spec:
       file: debian/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionNanoServer:
+    name: "Bump JDK11 default ARG version on Windows NanoServer Dockerfile"
+    kind: dockerfile
+    sourceid: jdk11LastVersion
+    spec:
+      file: windows/nanoserver-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionServerCore:
+    name: "Bump JDK11 default ARG version on Windows Server Core Dockerfile"
+    kind: dockerfile
+    sourceid: jdk11LastVersion
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION


### PR DESCRIPTION
There is already a `JAVA_VERSION` present in the Dockerfiles and the Docker bake file, but it is currently not being handled by `updatecli`.

I would like to propose making the necessary changes to update the Linux and Windows Dockerfiles and the Docker bake file accordingly. 

These modifications are mostly based on the work already done on [`docker-agent`](https://raw.githubusercontent.com/jenkinsci/docker-agent/c9f7b17801eadd0c73437f82af9302ef3cb77738/updatecli/updatecli.d/jdk17.yaml).

### Testing done

```bash
updatecli diff --config updatecli/updatecli.d/temurin.yaml --values updatecl
i/values.github-action.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/temurin.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



################################
# BUMP TEMURIN'S JDK17 VERSION #
################################


SOURCES
=======

jdk11LastVersion
----------------
Searching for version matching pattern "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
✔ Github Release version "jdk-11.0.19+7" found matching pattern "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"


CHANGELOG:
----------

Release published on the 2023-04-19 15:13:47 +0000 UTC at the url https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.19%2B7

Official Release of jdk-11.0.19+7

jdk17LastVersion
----------------
Searching for version matching pattern "^jdk-17.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
✔ Github Release version "jdk-17.0.7+7" found matching pattern "^jdk-17.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"


CHANGELOG:
----------

Release published on the 2023-04-19 13:34:51 +0000 UTC at the url https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.7%2B7

Official Release of jdk-17.0.7+7


CONDITIONS:
===========

checkTemurinJDK11WindowsCoreDockerImage
---------------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-windowsservercore-1809 (amd64) exists and is available.

checkTemurinJDK11DebianDockerImages
-----------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-focal (amd64) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-focal (arm64) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-focal (s390x) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-focal (arm/v7) exists and is available.

checkTemurinJDK11AlpineDockerImage
----------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:11.0.19_7-jdk-alpine (amd64) exists and is available.

checkTemurinJDK17WindowsCoreDockerImage
---------------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-windowsservercore-1809 (amd64) exists and is available.

checkTemurinJDK17DebianDockerImages
-----------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal (amd64) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal (arm64) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal (s390x) exists and is available.
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal (arm/v7) exists and is available.

checkTemurinJDK17AlpineDockerImage
----------------------------------
✔ The Docker image index.docker.io/library/eclipse-temurin:17.0.7_7-jdk-alpine (amd64) exists and is available.


TARGETS
========

setJDK11VersionDockerBake
-------------------------

**Dry Run enabled**

✔ Content from file "/tmp/updatecli/github/jenkinsci/docker-ssh-agent/docker-bake.hcl" already up to date
✔ All contents from 'file' and 'files' combined already up to date

setJDK17VersionDebian
---------------------

**Dry Run enabled**


🐋 On (Docker)file "/tmp/updatecli/github/jenkinsci/docker-ssh-agent/debian/Dockerfile":

✔ The line #1, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=17.0.7_7".

setJDK17VersionAlpine
---------------------

**Dry Run enabled**


🐋 On (Docker)file "/tmp/updatecli/github/jenkinsci/docker-ssh-agent/alpine/Dockerfile":

⚠ The line #23, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is changed from "ARG JAVA_VERSION=\"17.0.7_7\"" to "ARG JAVA_VERSION=17.0.7_7".

setJDK17VersionDockerBake
-------------------------

**Dry Run enabled**

✔ Content from file "/tmp/updatecli/github/jenkinsci/docker-ssh-agent/docker-bake.hcl" already up to date
✔ All contents from 'file' and 'files' combined already up to date


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:


⚠ Bump Temurin's JDK17 version:
        Source:
                ✔ [jdk11LastVersion] Get the latest Temurin JDK11 version (kind: githubrelease)
                ✔ [jdk17LastVersion] Get the latest Temurin JDK17 version (kind: githubrelease)
        Condition:
                ✔ [checkTemurinJDK11AlpineDockerImage] Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-alpine" is available (kind: dockerimage)
                ✔ [checkTemurinJDK11DebianDockerImages] Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-focal" is available (kind: dockerimage)
                ✔ [checkTemurinJDK11WindowsCoreDockerImage] Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-windowsservercore-1809" is available (kind: dockerimage)
                ✔ [checkTemurinJDK17AlpineDockerImage] Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-alpine" is available (kind: dockerimage)
                ✔ [checkTemurinJDK17DebianDockerImages] Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-focal" is available (kind: dockerimage)
                ✔ [checkTemurinJDK17WindowsCoreDockerImage] Check if the container image "eclipse-temurin:<jdk17LastVersion>-jdk-windowsservercore-1809" is available (kind: dockerimage)
        Target:
                ✔ [setJDK11VersionDockerBake] Bump JDK11 version for Linux images in the docker-bake.hcl file (kind: file)
                ⚠ [setJDK17VersionAlpine] Bump JDK17 default ARG version on Alpine Dockerfile (kind: dockerfile)
                ✔ [setJDK17VersionDebian] Bump JDK17 default ARG version on Debian Dockerfile (kind: dockerfile)
                ✔ [setJDK17VersionDockerBake] Bump JDK17 version for Linux images in the docker-bake.hcl file (kind: file)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
