### PR TITLE
Added support for building jenkins-ci for next version of debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The image has several supported configurations, which can be accessed via the fo
 
 `${IMAGE_VERSION}` can be found on the [releases](https://github.com/jenkinsci/docker-ssh-agent/releases) page.
 
-* `latest`, `latest-jdk11`, `jdk11`, `latest-bullseye-jdk11`, `bullseye-jdk11`, `latest-bookwrom-jdk11`, `bookworm-jdk11`, `latest-debian-jdk11`, `debian-jdk11`, `${IMAGE_VERSION}`, `${IMAGE_VERSION}-jdk11`, ([Dockerfile](debian/Dockerfile))
+* `latest`, `latest-jdk11`, `jdk11`, `latest-bullseye-jdk11`, `bullseye-jdk11`, `latest-bookworm-jdk11`, `bookworm-jdk11`, `latest-debian-jdk11`, `debian-jdk11`, `${IMAGE_VERSION}`, `${IMAGE_VERSION}-jdk11`, ([Dockerfile](debian/Dockerfile))
 * `latest-jdk17`, `jdk17`, `latest-bullseye-jdk17`, `bullseye-jdk17`, `latest-bookworm-jdk17`, `bookworm-jdk17`, `latest-debian-jdk17`, `debian-jdk17`, `${IMAGE_VERSION}-jdk17`, ([Dockerfile](debian/Dockerfile))
 * `nanoserver-1809`, `nanoserver-ltsc2019`, `nanoserver-1809-jdk11`, `nanoserver-ltsc2019-jdk11`, `${IMAGE_VERSION}-nanoserver-1809`, `${IMAGE_VERSION}-nanoserver-ltsc2019`, `${IMAGE_VERSION}-nanoserver-1809-jdk11`, `${IMAGE_VERSION}-nanoserver-ltsc2019-jdk11` ([Dockerfile](windows/nanoserver-ltsc2019/Dockerfile))
 * `windowsservercore-1809`, `windowsservercore-ltsc2019`, `windowsservercore-1809-jdk11`, `windowsservercore-ltsc2019-jdk11`, `${IMAGE_VERSION}-windowsservercore-1809`, `${IMAGE_VERSION}-windowsservercore-ltsc2019`, `${IMAGE_VERSION}-windowsservercore-1809-jdk11`, `${IMAGE_VERSION}-windowsservercore-ltsc2019-jdk11` ([Dockerfile](windows/windowsservercore-ltsc2019/Dockerfile))

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The image has several supported configurations, which can be accessed via the fo
 
 `${IMAGE_VERSION}` can be found on the [releases](https://github.com/jenkinsci/docker-ssh-agent/releases) page.
 
-* `latest`, `latest-jdk11`, `jdk11`, `latest-bullseye-jdk11`, `bullseye-jdk11`, `latest-debian-jdk11`, `debian-jdk11`, `${IMAGE_VERSION}`, `${IMAGE_VERSION}-jdk11`, ([Dockerfile](debian/Dockerfile))
-* `latest-jdk17`, `jdk17`, `latest-bullseye-jdk17`, `bullseye-jdk17`,`latest-debian-jdk17`, `debian-jdk17`, `${IMAGE_VERSION}-jdk17`, ([Dockerfile](debian/Dockerfile))
+* `latest`, `latest-jdk11`, `jdk11`, `latest-bullseye-jdk11`, `bullseye-jdk11`, `latest-bookwrom-jdk11`, `bookworm-jdk11`, `latest-debian-jdk11`, `debian-jdk11`, `${IMAGE_VERSION}`, `${IMAGE_VERSION}-jdk11`, ([Dockerfile](debian/Dockerfile))
+* `latest-jdk17`, `jdk17`, `latest-bullseye-jdk17`, `bullseye-jdk17`, `latest-bookworm-jdk17`, `bookworm-jdk17`, `latest-debian-jdk17`, `debian-jdk17`, `${IMAGE_VERSION}-jdk17`, ([Dockerfile](debian/Dockerfile))
 * `nanoserver-1809`, `nanoserver-ltsc2019`, `nanoserver-1809-jdk11`, `nanoserver-ltsc2019-jdk11`, `${IMAGE_VERSION}-nanoserver-1809`, `${IMAGE_VERSION}-nanoserver-ltsc2019`, `${IMAGE_VERSION}-nanoserver-1809-jdk11`, `${IMAGE_VERSION}-nanoserver-ltsc2019-jdk11` ([Dockerfile](windows/nanoserver-ltsc2019/Dockerfile))
 * `windowsservercore-1809`, `windowsservercore-ltsc2019`, `windowsservercore-1809-jdk11`, `windowsservercore-ltsc2019-jdk11`, `${IMAGE_VERSION}-windowsservercore-1809`, `${IMAGE_VERSION}-windowsservercore-ltsc2019`, `${IMAGE_VERSION}-windowsservercore-1809-jdk11`, `${IMAGE_VERSION}-windowsservercore-ltsc2019-jdk11` ([Dockerfile](windows/windowsservercore-ltsc2019/Dockerfile))
 
@@ -110,6 +110,8 @@ alpine_jdk11
 alpine_jdk17
 debian_jdk11
 debian_jdk17
+debian_next_jdk11
+debian_next_jdk17
 ```
 
 #### Building a specific image
@@ -167,7 +169,9 @@ make show
         "alpine_jdk17",
         "alpine_jdk11",
         "debian_jdk11",
-        "debian_jdk17"
+        "debian_jdk17",
+        "debian_next_jdk11",
+        "debian_next_jdk17"
       ]
     }
   },

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,6 +4,8 @@ group "linux" {
     "alpine_jdk11",
     "debian_jdk11",
     "debian_jdk17",
+    "debian_next_jdk11",
+    "debian_next_jdk17",
   ]
 }
 
@@ -11,6 +13,8 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_next_jdk11",
+    "debian_next_jdk17",
   ]
 }
 
@@ -24,6 +28,8 @@ group "linux-ppc64le" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_next_jdk11",
+    "debian_next_jdk17",
   ]
 }
 
@@ -57,6 +63,14 @@ variable "JAVA11_VERSION" {
 
 variable "JAVA17_VERSION" {
   default = "17.0.7_7"
+}
+
+variable "DEBIAN_RELEASE" {
+  default = "bullseye-20230522"
+}
+
+variable "DEBIAN_NEXT_RELEASE" {
+  default = "bookworm-20230522"
 }
 
 target "alpine_jdk17" {
@@ -103,6 +117,7 @@ target "debian_jdk11" {
   context = "."
   args = {
     JAVA_VERSION = JAVA11_VERSION
+    DEBIAN_RELEASE = DEBIAN_RELEASE
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}": "",
@@ -118,11 +133,27 @@ target "debian_jdk11" {
   platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
 }
 
+target "debian_next_jdk11" {
+  dockerfile = "debian/Dockerfile"
+  context = "."
+  args = {
+    JAVA_VERSION = JAVA11_VERSION
+    DEBIAN_RELEASE = DEBIAN_NEXT_RELEASE
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:bookworm-${VERSION}-jdk11": "",
+    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk11",
+  ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+}
+
 target "debian_jdk17" {
   dockerfile = "debian/Dockerfile"
   context = "."
   args = {
     JAVA_VERSION = JAVA17_VERSION
+    DEBIAN_RELEASE = DEBIAN_RELEASE
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk17": "",
@@ -132,6 +163,21 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
+  ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+}
+
+target "debian_next_jdk17" {
+  dockerfile = "debian/Dockerfile"
+  context = "."
+  args = {
+    JAVA_VERSION = JAVA17_VERSION
+    DEBIAN_RELEASE = DEBIAN_NEXT_RELEASE
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:bookworm-${VERSION}-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk17",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }


### PR DESCRIPTION
This is a replacement for https://github.com/jenkinsci/docker-ssh-agent/pull/255 . 

https://wiki.debian.org/DebianBookworm

Debian bookworm is releasing in ~ 10 days. 
Code wise there will be no breaking changes, only bug fixes.

I believe it's time to consider publishing an updated version based on bookworm.
For our use case we need a newer release of buildah. 

### Testing done

make build
make test

Will push and use in our infra soon. 

### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
