### PR TITLE
feature(updatecli) Tracks npm and node

### DIFF
--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -1,0 +1,207 @@
+---
+name: Bumps the node docker images versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  nodeLatestVersion:
+    kind: githubrelease
+    spec:
+      owner: "nodejs"
+      repository: "node"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: "v"
+  alpineLatestVersion:
+    kind: githubrelease
+    name: "Get the latest Alpine Linux version"
+    spec:
+      owner: "alpinelinux"
+      repository: "aports" # Its release process follows Alpine's
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+        pattern: "~3"
+    transformers:
+      - findsubmatch:
+          pattern: >-
+            v(.*)(\.\d+)
+          captureindex: 1
+
+conditions:
+  testNodeArg:
+    name: "Does the 'Hello World!' tutorial have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        .*agent.*docker.*image.*node:.*
+  testNodeInAgentsDocumentation:
+    name: "Does the 'Defining execution environments' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/pipeline/tour/agents.adoc
+      matchpattern: >-
+        .*docker.*image.*node:.*
+  testNodeInStyleGuideDocumentation:
+    name: "Does the 'Jenkins Documentation Style Guide' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: STYLEGUIDE.adoc
+      matchpattern: >-
+        .*docker.*image.*node:.*
+  testNodeInPipelineProjectCreationTutorial:
+    name: "Does the 'End-to-End Multibranch Pipeline Project Creation' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+      matchpattern: >-
+        .*image.*node:.*
+  testNodeInBuildANodeJsAndReactAppWithNpmTutorial:
+    name: "Does the 'End-to-End Multibranch Pipeline Project Creation' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+      matchpattern: >-
+        .*image.*node:.*
+  testNodeInUsingDockerWithPipelineDocumentation:
+    name: "Does the 'Using Docker with Pipeline' documentation have a reference to the Node alpine image?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        .*image.*node:.*
+  testNodeAlpineImagePublished:
+    name: "Test node:<latest_version>-alpine<latest-version> docker image tag"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      image: "node"
+      tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
+
+targets:
+  updateHelloWorldTutorialNodePipeline:
+    name: "Update the value of the node docker image for pipelines in the 'Hello World!' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        (.*agent.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateHelloWorldTutorialNodeScripted:
+    name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/hello-world.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateAgentsDocumentation:
+    name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/pipeline/tour/agents.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateStyleGuideDocumentation:
+    name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: STYLEGUIDE.adoc
+      matchpattern: >-
+        (.*docker.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updatePipelineProjectCreationTutorial:
+    name: "Update the value of the node docker image in the 'End-to-End Multibranch Pipeline Project Creation' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+      matchpattern: >-
+        (.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateBuildANodeJsAndReactAppWithNpmTutorial:
+    name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+      matchpattern: >-
+        (.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateBuildANodeJsAndReactAppWithNpmDockerHubLinkTutorial:
+    name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+      matchpattern: >-
+        (https.*\`)node:(.*)(\`.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateUsingDockerWithPipelineDocumentation:
+    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        (.*image.*\')node:(.*)(\'.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+  updateUsingDockerWithPipelineDocumentationDockerExample:
+    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
+    kind: file
+    sourceid: nodeLatestVersion
+    spec:
+      file: content/doc/book/pipeline/docker.adoc
+      matchpattern: >-
+        (FROM )node:(.*)(.*)
+      replacepattern: >-
+        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
+    scmid: default
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump node alpine docker image version to {{ source "nodeLatestVersion" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bumps the node docker images versions
+name: Bumps the node docker images version
 
 scms:
   default:
@@ -42,53 +42,13 @@ sources:
 
 conditions:
   testNodeArg:
-    name: "Does the 'Hello World!' tutorial have a reference to the Node alpine image?"
+    name: "Does the Makefile have a reference to the Node alpine image?"
     kind: file
     disablesourceinput: true
     spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
+      file: Makefile
       matchpattern: >-
-        .*agent.*docker.*image.*node:.*
-  testNodeInAgentsDocumentation:
-    name: "Does the 'Defining execution environments' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/pipeline/tour/agents.adoc
-      matchpattern: >-
-        .*docker.*image.*node:.*
-  testNodeInStyleGuideDocumentation:
-    name: "Does the 'Jenkins Documentation Style Guide' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: STYLEGUIDE.adoc
-      matchpattern: >-
-        .*docker.*image.*node:.*
-  testNodeInPipelineProjectCreationTutorial:
-    name: "Does the 'End-to-End Multibranch Pipeline Project Creation' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
-      matchpattern: >-
-        .*image.*node:.*
-  testNodeInBuildANodeJsAndReactAppWithNpmTutorial:
-    name: "Does the 'End-to-End Multibranch Pipeline Project Creation' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
-      matchpattern: >-
-        .*image.*node:.*
-  testNodeInUsingDockerWithPipelineDocumentation:
-    name: "Does the 'Using Docker with Pipeline' documentation have a reference to the Node alpine image?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        .*image.*node:.*
+        .*docker.*run.*node:.*
   testNodeAlpineImagePublished:
     name: "Test node:<latest_version>-alpine<latest-version> docker image tag"
     kind: dockerimage
@@ -98,110 +58,23 @@ conditions:
       tag: '{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}'
 
 targets:
-  updateHelloWorldTutorialNodePipeline:
-    name: "Update the value of the node docker image for pipelines in the 'Hello World!' tutorial"
+  updateMakefile:
+    name: "Updates the value of the node docker image in the Makefile"
     kind: file
     sourceid: nodeLatestVersion
     spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
+      file: Makefile
       matchpattern: >-
-        (.*agent.*docker.*image.*\')node:(.*)(\'.*)
+        (.*docker.*run.*)node:.*( .*)
       replacepattern: >-
         ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
     scmid: default
-  updateHelloWorldTutorialNodeScripted:
-    name: "Update the value of the node docker image for scripts in the 'Hello World!' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/pipeline/tour/hello-world.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateAgentsDocumentation:
-    name: "Update the value of the node docker image in the 'Defining execution environments' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/pipeline/tour/agents.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateStyleGuideDocumentation:
-    name: "Update the value of the node docker image in the 'Jenkins Documentation Style Guide' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: STYLEGUIDE.adoc
-      matchpattern: >-
-        (.*docker.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updatePipelineProjectCreationTutorial:
-    name: "Update the value of the node docker image in the 'End-to-End Multibranch Pipeline Project Creation' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
-      matchpattern: >-
-        (.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateBuildANodeJsAndReactAppWithNpmTutorial:
-    name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
-      matchpattern: >-
-        (.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateBuildANodeJsAndReactAppWithNpmDockerHubLinkTutorial:
-    name: "Update the value of the node docker image in the 'Build a Node.js and React app with npm' tutorial"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
-      matchpattern: >-
-        (https.*\`)node:(.*)(\`.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateUsingDockerWithPipelineDocumentation:
-    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        (.*image.*\')node:(.*)(\'.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
-  updateUsingDockerWithPipelineDocumentationDockerExample:
-    name: "Update the value of the node docker image in the 'Using Docker with Pipeline' documentation"
-    kind: file
-    sourceid: nodeLatestVersion
-    spec:
-      file: content/doc/book/pipeline/docker.adoc
-      matchpattern: >-
-        (FROM )node:(.*)(.*)
-      replacepattern: >-
-        ${1}node:{{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}${3}
-    scmid: default
+
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump node alpine docker image version to {{ source "nodeLatestVersion" }}
+    title: Bump node alpine docker image version to {{ source "nodeLatestVersion" }}-alpine{{ source "alpineLatestVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/npm.yaml
+++ b/updatecli/updatecli.d/npm.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bumps the npm versions
+name: Bumps the npm version
 
 scms:
   default:
@@ -40,7 +40,7 @@ conditions:
 
 targets:
   updateMakefile:
-    name: "Update the value of the npm version in the Makefile"
+    name: "Updates the value of the npm version in the Makefile"
     kind: file
     sourceid: npmLatestVersion
     spec:
@@ -50,3 +50,13 @@ targets:
       replacepattern: >-
         ${1}{{ source "npmLatestVersion" }}${3}${{4}}
     scmid: default
+    
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump npm version to {{ source "npmLatestVersion" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/npm.yaml
+++ b/updatecli/updatecli.d/npm.yaml
@@ -1,0 +1,52 @@
+---
+name: Bumps the npm versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  npmLatestVersion:
+    kind: githubrelease
+    spec:
+      owner: "npm"
+      repository: "cli"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        pattern: >-
+          ^v\d+\.\d+.\d+$
+    transformers:
+      - trimprefix: "v"
+
+conditions:
+  testNodeArg:
+    name: "Does the Makefile have a reference to npm?"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: >-
+        .*npm.* install.*-g.*npm@.*.*npm.*install.*
+
+targets:
+  updateMakefile:
+    name: "Update the value of the npm version in the Makefile"
+    kind: file
+    sourceid: npmLatestVersion
+    spec:
+      file: Makefile
+      matchpattern: >-
+        (.*sh -c "npm install -g npm@)(.*)( && npm install)(.*)
+      replacepattern: >-
+        ${1}{{ source "npmLatestVersion" }}${3}${{4}}
+    scmid: default


### PR DESCRIPTION
Following #266 where I saw @MarkEWaite had to update the `npm` version by hand, I propose to let `updatecli` do it for us.

### Testing done

```bash
updatecli diff --debug --config updatecli/updatecli.d/npm.yaml --values updatecli/values.github-action.yaml
updatecli diff --debug --config updatecli/updatecli.d/node.yaml --values updatecli/values.github-action.yaml
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
