### PR TITLE
chore(Makefile) Fix the Makfile (Latest updatecli removed the trailing `\`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-%: prepare-test
 	set -x
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18.16.1-alpine3.18
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18.16.1-alpine3.18 \
 		sh -c "npm install -g npm@9.7.2 && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test


### PR DESCRIPTION
My `node`  and `npm` [tracking](#267 ) did not work as expected, as it removed the trailing `/`.

I will correct the updatecli pipeline too in another PR.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
