### PR TITLE
chore(updatecli) track version of git-lfs on Windows

### DIFF
--- a/updatecli/updatecli.d/git-lfs-windows.yml
+++ b/updatecli/updatecli.d/git-lfs-windows.yml
@@ -1,0 +1,58 @@
+
+---
+name: Bump `git-lfs` version on Windows
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest `git-lfs` version
+    spec:
+      owner: git-lfs
+      repository: git-lfs
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+targets:
+  setGitLfsVersionWindowsNanoserver2019:
+    name: Update the `git-lfs` Windows version for Windows Nanoserver 2019
+    kind: dockerfile
+    spec:
+      file: windows/nanoserver-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_LFS_VERSION
+    scmid: default
+  setGitLfsVersionWindowsServer2019:
+    name: Update the `git-lfs` Windows version for Windows Core Server 2019
+    kind: dockerfile
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_LFS_VERSION
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `git-lfs` version on Windows to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - git-lfs
+        - windows

--- a/updatecli/updatecli.d/git-lfs-windows.yml
+++ b/updatecli/updatecli.d/git-lfs-windows.yml
@@ -1,5 +1,3 @@
-
----
 name: Bump `git-lfs` version on Windows
 
 scms:

--- a/windows/nanoserver-ltsc2019/Dockerfile
+++ b/windows/nanoserver-ltsc2019/Dockerfile
@@ -50,9 +50,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.1.4
+ARG GIT_LFS_VERSION=v3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
+    $url = $('https://github.com/git-lfs/git-lfs/releases/download/{0}/git-lfs-windows-amd64-{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `

--- a/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/windows/windowsservercore-ltsc2019/Dockerfile
@@ -48,9 +48,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.1.4
+ARG GIT_LFS_VERSION=v3.1.4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
+    $url = $('https://github.com/git-lfs/git-lfs/releases/download/{0}/git-lfs-windows-amd64-{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `


### PR DESCRIPTION
This PR introduces an updatecli manifest to track the `git-lfs` versions (and open a Pull Request when a new versions is available).

Please note that the `git-lfs` tag and GitHub releases have a `v` prefix so the Dockerfiles are updated to take this in account

### Testing done

- Ran locally an `updatecli diff --values ./updatecli/values.github-action.yaml  --config ./updatecli/updatecli.d/git-lfs-windows.yml` command which picked the latest `v3.3.0` version instead of the current `3.1.4`
- Once merged, a new PR should be opened by updatecli to pick this new version (as a "real life test") with a passing set of checks

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
