### PR TITLE
Tracks Debian bookworm version thanks to updatecli

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,5 @@
 ARG JAVA_VERSION=17.0.8_7
+ARG BOOKWORM_TAG=20230814
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal AS jre-build
 
 # This Build ARG is populated by Docker
@@ -32,7 +33,7 @@ RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
     else cp -r /opt/java/openjdk /javaruntime; \
     fi
 
-FROM debian:bullseye-20230814
+FROM debian:bookworm-${BOOKWORM_TAG}
 
 ARG user=jenkins
 ARG group=jenkins

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,6 +59,10 @@ variable "JAVA17_VERSION" {
   default = "17.0.8_7"
 }
 
+variable "BOOKWORM_TAG" {
+  default = "20230814"
+}
+
 target "alpine_jdk17" {
   dockerfile = "alpine/Dockerfile"
   context = "."
@@ -103,6 +107,7 @@ target "debian_jdk11" {
   context = "."
   args = {
     JAVA_VERSION = JAVA11_VERSION
+    BOOKWORM_TAG = BOOKWORM_TAG
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}": "",
@@ -123,6 +128,7 @@ target "debian_jdk17" {
   context = "."
   args = {
     JAVA_VERSION = JAVA17_VERSION
+    BOOKWORM_TAG = BOOKWORM_TAG
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk17": "",

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -74,4 +74,3 @@ actions:
     spec:
       labels:
         - dependencies
-

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -1,0 +1,90 @@
+---
+name: Bump Debian Bookworm version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  bookwormLatestVersion:
+    kind: dockerimage
+    name: "Get the latest Debian Bookworm Linux version"
+    transformers:
+      - trimprefix: "bookworm-"
+    spec:
+      image: "debian"
+      tagFilter: "bookworm-*"
+      versionfilter:
+        kind: regex
+        pattern: >-
+          bookworm-\d+$
+  bookwormSlimLatestVersion:
+    kind: dockerimage
+    name: "Get the latest Debian Bookworm Linux version"
+    transformers:
+      - trimprefix: "bookworm-"
+    spec:
+      image: "debian"
+      tagFilter: "bookworm-*"
+      versionfilter:
+        kind: regex
+        pattern: >-
+          bookworm-\d+-slim$
+
+conditions:
+  testDockerfileArg:
+    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: debian/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BOOKWORM_TAG"
+  testVersionInBakeFile:
+    name: "Does the bake file have variable BOOKWORM_TAG"
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: docker-bake.hcl
+      matchpattern: "(.*BOOKWORM_TAG.*)"
+
+targets:
+  updateDockerfile:
+    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
+    kind: dockerfile
+    sourceid: bookwormLatestVersion
+    spec:
+      file: 11/debian/bookworm/hotspot/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BOOKWORM_TAG"
+    scmid: default
+  updateDockerBake:
+    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the docker-bake.hcl"
+    kind: file
+    sourceid: bookwormLatestVersion
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"BOOKWORM_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"BOOKWORM_TAG"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
+    scmid: default
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Debian Bookworm Linux Version to {{ source "bookwormLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -49,7 +49,7 @@ targets:
     kind: dockerfile
     sourceid: bookwormLatestVersion
     spec:
-      file: 11/debian/bookworm/hotspot/Dockerfile
+      file: debian/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "DEBIAN_RELEASE"

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -25,24 +25,6 @@ sources:
         pattern: >-
           bookworm-\d+$
 
-conditions:
-  testDockerfileArg:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: debian/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "DEBIAN_RELEASE"
-  testVersionInBakeFile:
-    name: "Does the bake file have variable DEBIAN_RELEASE?"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: docker-bake.hcl
-      matchpattern: "(.*DEBIAN_RELEASE.*)"
-
 targets:
   updateDockerfile:
     name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile"

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -65,6 +65,7 @@ targets:
       replacepattern: >-
         variable${1}"DEBIAN_RELEASE"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
     scmid: default
+
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -17,8 +17,6 @@ sources:
   bookwormLatestVersion:
     kind: dockerimage
     name: "Get the latest Debian Bookworm Linux version"
-    transformers:
-      - trimprefix: "bookworm-"
     spec:
       image: "debian"
       tagFilter: "bookworm-*"
@@ -26,18 +24,6 @@ sources:
         kind: regex
         pattern: >-
           bookworm-\d+$
-  bookwormSlimLatestVersion:
-    kind: dockerimage
-    name: "Get the latest Debian Bookworm Linux version"
-    transformers:
-      - trimprefix: "bookworm-"
-    spec:
-      image: "debian"
-      tagFilter: "bookworm-*"
-      versionfilter:
-        kind: regex
-        pattern: >-
-          bookworm-\d+-slim$
 
 conditions:
   testDockerfileArg:
@@ -48,36 +34,36 @@ conditions:
       file: debian/Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
+        matcher: "DEBIAN_RELEASE"
   testVersionInBakeFile:
-    name: "Does the bake file have variable BOOKWORM_TAG"
+    name: "Does the bake file have variable DEBIAN_RELEASE?"
     kind: file
     disablesourceinput: true
     spec:
       file: docker-bake.hcl
-      matchpattern: "(.*BOOKWORM_TAG.*)"
+      matchpattern: "(.*DEBIAN_RELEASE.*)"
 
 targets:
   updateDockerfile:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
+    name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile"
     kind: dockerfile
     sourceid: bookwormLatestVersion
     spec:
       file: 11/debian/bookworm/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
+        matcher: "DEBIAN_RELEASE"
     scmid: default
   updateDockerBake:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the docker-bake.hcl"
+    name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the docker-bake.hcl"
     kind: file
     sourceid: bookwormLatestVersion
     spec:
       file: docker-bake.hcl
       matchpattern: >-
-        variable(.*)"BOOKWORM_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+        variable(.*)"DEBIAN_RELEASE"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
       replacepattern: >-
-        variable${1}"BOOKWORM_TAG"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
+        variable${1}"DEBIAN_RELEASE"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
     scmid: default
 actions:
   default:

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -70,7 +70,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Debian Bookworm Linux Version to {{ source "bookwormLatestVersion" }}
+    title: Bump Debian Bookworm Linux version to {{ source "bookwormLatestVersion" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
I have used the latest tag defined in `docker-bake.hcl` (`DEBIAN_RELEASE`) to get `updatecli` to update the Debian version in the `Dockerfile` (for historical reasons) and in the `docker-bake.hcl`.

`updatecli` [fails](https://github.com/jenkinsci/docker-ssh-agent/actions/runs/5926615651/job/16068368965?pr=301#step:4:144) because it can't find (yet) `DEBIAN_RELEASE` in `debian/Dockerfile`.
This should be fixed when this PR is merged. 🤷 

### Testing done

` updatecli apply --config ./updatecli/updatecli.d/debian.yaml --values ./updatecli/values.github-action.yaml`

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
