### PR TITLE
chore(updatecli) switch to HCL native resource + manifest fixes

### DIFF
--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -46,13 +46,6 @@ conditions:
       image: "alpine"
       # tag come from the source
       architecture: amd64
-  testVersionInBakeFile:
-    name: "Does the bake file have variable ALPINE_VERSION"
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: docker-bake.hcl
-      matchpattern: "(.*ALPINE_FULL_TAG.*)"
 
 targets:
   updateDockerfile:
@@ -66,13 +59,10 @@ targets:
     scmid: default
   updateDockerBake:
     name: "Update the value of the base image (ARG ALPINE_TAG) in the docker-bake.hcl"
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"ALPINE_FULL_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"ALPINE_FULL_TAG"${2}{${3}${4}${5}default${6}= "{{ source "latestVersion" }}"
+      path: variable.ALPINE_FULL_TAG.default
     scmid: default
 actions:
   default:

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -19,7 +19,7 @@ sources:
     name: "Get the latest Debian Bookworm Linux version"
     spec:
       image: "debian"
-      tagFilter: "bookworm-*"
+      tagfilter: "bookworm-*"
       versionfilter:
         kind: regex
         pattern: >-

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -37,15 +37,12 @@ targets:
         matcher: "DEBIAN_RELEASE"
     scmid: default
   updateDockerBake:
-    name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the docker-bake.hcl"
-    kind: file
+    name: "Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl"
+    kind: hcl
     sourceid: bookwormLatestVersion
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"DEBIAN_RELEASE"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"DEBIAN_RELEASE"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
+      path: variable.DEBIAN_RELEASE.default
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -1,0 +1,103 @@
+---
+name: Bump Temurin's JDK11 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  jdk11LastVersion:
+    kind: githubrelease
+    name: Get the latest Temurin JDK11 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin11-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-11.0.20+8 ()https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20%2B8) is OK
+        # jdk-11.0.20.1+1(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20.1%2B1) is OK
+        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+      - replacer:
+          from: +
+          to: _
+
+conditions:
+  checkTemurinJDK11AlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-alpine" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-alpine'
+  checkTemurinJDK11DebianDockerImages:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architectures:
+        - amd64
+        - arm64
+        - s390x
+        - arm/v7
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-focal'
+  checkTemurinJDK11WindowsCoreDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-windowsservercore-1809" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "jdk11LastVersion" }}-jdk-windowsservercore-1809'
+
+targets:
+  setJDK11VersionNanoServer:
+    name: "Bump JDK11 default ARG version on Windows NanoServer Dockerfile"
+    kind: dockerfile
+    sourceid: jdk11LastVersion
+    spec:
+      file: windows/nanoserver-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionServerCore:
+    name: "Bump JDK11 default ARG version on Windows Server Core Dockerfile"
+    kind: dockerfile
+    sourceid: jdk11LastVersion
+    spec:
+      file: windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionDockerBake:
+    name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
+    kind: hcl
+    sourceid: jdk11LastVersion
+    spec:
+      file: docker-bake.hcl
+      path: variable.JAVA11_VERSION.default
+    scmid: default
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK11 version to {{ source "jdk11LastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk11

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -32,23 +32,6 @@ sources:
       - replacer:
           from: +
           to: _
-  jdk11LastVersion:
-    kind: githubrelease
-    name: Get the latest Temurin JDK11 version
-    spec:
-      owner: "adoptium"
-      repository: "temurin11-binaries"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: regex
-        # jdk-11.0.4.1+1(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.4.1%2B1) is OK
-        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
-    transformers:
-      - trimprefix: "jdk-"
-      - replacer:
-          from: +
-          to: _
 
 conditions:
   checkTemurinJDK17AlpineDockerImage:
@@ -79,34 +62,6 @@ conditions:
       architecture: amd64
       image: eclipse-temurin
       tag: '{{source "jdk17LastVersion" }}-jdk-windowsservercore-1809'
-  checkTemurinJDK11AlpineDockerImage:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-alpine" is available
-    disablesourceinput: true
-    spec:
-      architecture: amd64
-      image: eclipse-temurin
-      tag: '{{source "jdk11LastVersion" }}-jdk-alpine'
-  checkTemurinJDK11DebianDockerImages:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architectures:
-        - amd64
-        - arm64
-        - s390x
-        - arm/v7
-      image: eclipse-temurin
-      tag: '{{source "jdk11LastVersion" }}-jdk-focal'
-  checkTemurinJDK11WindowsCoreDockerImage:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<jdk11LastVersion>-jdk-windowsservercore-1809" is available
-    disablesourceinput: true
-    spec:
-      architecture: amd64
-      image: eclipse-temurin
-      tag: '{{source "jdk11LastVersion" }}-jdk-windowsservercore-1809'
 
 targets:
   setJDK17VersionDockerBake:
@@ -137,34 +92,7 @@ targets:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-  setJDK11VersionNanoServer:
-    name: "Bump JDK11 default ARG version on Windows NanoServer Dockerfile"
-    kind: dockerfile
-    sourceid: jdk11LastVersion
-    spec:
-      file: windows/nanoserver-ltsc2019/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionServerCore:
-    name: "Bump JDK11 default ARG version on Windows Server Core Dockerfile"
-    kind: dockerfile
-    sourceid: jdk11LastVersion
-    spec:
-      file: windows/windowsservercore-ltsc2019/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionDockerBake:
-    name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
-    kind: hcl
-    sourceid: jdk11LastVersion
-    spec:
-      file: docker-bake.hcl
-      path: variable.JAVA11_VERSION.default
-    scmid: default
+
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/npm.yaml
+++ b/updatecli/updatecli.d/npm.yaml
@@ -50,13 +50,12 @@ targets:
       replacepattern: >-
         ${1}{{ source "npmLatestVersion" }}${3}${{4}}
     scmid: default
-    
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: chore(tests): Bump NPM version to {{ source "npmLatestVersion" }}
+    title: 'chore(tests): Bump NPM version to {{ source "npmLatestVersion" }}'
     spec:
       labels:
         - chore # Because NPM is only used for testing

--- a/updatecli/updatecli.d/temurin.yaml
+++ b/updatecli/updatecli.d/temurin.yaml
@@ -107,18 +107,15 @@ conditions:
       architecture: amd64
       image: eclipse-temurin
       tag: '{{source "jdk11LastVersion" }}-jdk-windowsservercore-1809'
-      
+
 targets:
   setJDK17VersionDockerBake:
     name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
-    kind: file
+    kind: hcl
     sourceid: jdk17LastVersion
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"JAVA17_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "jdk17LastVersion" }}"
+      path: variable.JAVA17_VERSION.default
     scmid: default
   setJDK17VersionAlpine:
     name: "Bump JDK17 default ARG version on Alpine Dockerfile"
@@ -162,14 +159,11 @@ targets:
     scmid: default
   setJDK11VersionDockerBake:
     name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
-    kind: file
+    kind: hcl
     sourceid: jdk11LastVersion
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"JAVA11_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"JAVA11_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "jdk11LastVersion" }}"
+      path: variable.JAVA11_VERSION.default
     scmid: default
 actions:
   default:


### PR DESCRIPTION
Since [0.55.0](https://github.com/updatecli/updatecli/releases/tag/v0.55.0), `updatecli` has a [native HCL resource](https://www.updatecli.io/docs/plugins/resource/hcl/).

This PR updates the manifest to replace the tedious "file resource with matchpattern regex" in favor of the native HCL and fix manifest errors caught along the way:

- Switching to native HCL fixes an error in the JD11 tracking which prevented the (unexpected) case of JDK11 with 4 digits (11.0.20.1_1).
- Fixup of a minor syntax error from #301 in the Debian manifest (`tagfilter` must be lowercase as per the schema)
- Fixup of a commit I pushed in #306 trying to have fancier PR title
- Fixup of #256 by splitting the Temurin manifest into distinct (JDK11 and JDK17) manifests to avoid "hidding" upgrades of the JDK11 inside a JDK17 PR (see https://github.com/jenkinsci/docker-ssh-agent/pull/307, I've manually update its title)