### PR TITLE
feat(platforms): Adds ppc64le, s390x and arm/v7 for JDK21

### DIFF
--- a/debian/21/Dockerfile
+++ b/debian/21/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["/bin/bash","-e", "-u", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
   && apt-get install --no-install-recommends -y ca-certificates curl jq \
-  && ARCH=$(uname -m | sed 's/x86_64/x64/') \
+  && ARCH=$(uname -m | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && JAVA_VERSION_ENCODED=$(printf '%s' "$JAVA_VERSION" | jq -jRr '@uri') \
   && BUILD_NUMBER=$(printf '%s' "$JAVA_VERSION" | cut -d'+' -f2) \
   && JAVA_MAJOR_VERSION=$(printf '%s' "$JAVA_VERSION" | cut -d'+' -f1) \
@@ -42,7 +42,7 @@ RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
         --output /javaruntime; \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
     # Because jlink fails with the error "jmods: Value too large for defined data type" error.
-    else cp -r /opt/java/openjdk /javaruntime; \
+    else cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
     fi
 
 FROM debian:"${DEBIAN_RELEASE}"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -183,5 +183,5 @@ target "debian_jdk21" {
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk21-preview",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk21-preview",
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/arm/v7"]
 }


### PR DESCRIPTION
After discussing with @ksalerno99 yesterday during the [Platform SIG meeting](https://www.jenkins.io/sigs/platform/), I considered that adding support for a few platforms for JDK21 would be beneficial.

I then propose to add `"linux/ppc64le"`, `"linux/arm/v7"` and `"linux/s390x"` as new target platforms for our JDK21 preview images.

### Testing done

`docker buildx bake --file docker-bake.hcl debian_jdk21`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
