### PR TITLE
chore(updatecli) track bats version

### DIFF
--- a/updatecli/updatecli.d/bats.yaml
+++ b/updatecli/updatecli.d/bats.yaml
@@ -1,0 +1,47 @@
+---
+name: Bump `bats` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    spec:
+      owner: bats-core
+      repository: bats-core
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+targets:
+  updateMakefile:
+    name: "Updates `bats` version in the Makefile"
+    kind: file
+    spec:
+      file: Makefile
+      matchpattern: >-
+        git clone --branch (.*) https://github.com/bats-core/bats-core bats
+      replacepattern: >-
+        git clone --branch {{ source "lastVersion" }} https://github.com/bats-core/bats-core bats
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: 'chore(tests): Bump `bats` version to {{ source "lastVersion" }}'
+    spec:
+      labels:
+        - chore # Because bats is only used for testing
+        - bats


### PR DESCRIPTION
Follow up of #344, this PR introduces an `updatecli` manifest to track the version of `bats`.

### Testing done

- Ran the command `updatecli diff --values ./updatecli/values.github-action.yaml --config ./updatecli/updatecli.d/bats.yaml` locally which succeded with "no changes"
- Tried to change (locally) the bats version to `v1.7.0`: the command `updatecli diff --values ./updatecli/values.github-action.yaml --config ./updatecli/updatecli.d/bats.yaml` (with target's `scmid` commented out) proposed to bump `v1.7.0` to `v1.10.0` in the `Makefile as expected
- CI check reports a success as well:

```
✔ Bump `bats` version:
	Source:
		✔ [lastVersion] 
	Target:
		✔ [updateMakefile] Updates `bats` version in the Makefile
```