### PR TITLE
fix(docker) Bring back Debian JDK17 images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,6 +4,7 @@ group "linux" {
     "alpine_jdk17",
     "alpine_jdk21",
     "debian_jdk11",
+    "debian_jdk17",
     "debian_jdk21",
     "debian_jdk21-preview",
   ]


### PR DESCRIPTION
In #371, I was [wondering](https://github.com/jenkinsci/docker-ssh-agent/pull/371#issuecomment-2014590156) why we lost the `debian_jdk17` target.
@lemeurherve [found](https://github.com/jenkinsci/docker-ssh-agent/pull/371#issuecomment-2014594285) the root cause quickly. I [removed](https://github.com/jenkinsci/docker-ssh-agent/commit/519ac2f83b9a0ea1f2ec473f35d4a4caf04289f5#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2) this target back in September 2023 (in #309) while adding the support for JDK21. 🤦 

Let's add it back before merging #371 .

### Testing done

`make build-alpine_jdk21  build-debian_jdk21  build-debian_jdk17  build-debian_jdk11 build-alpine_jdk17 build-alpine_jdk11`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue