### PR TITLE
chore(updatecli/jdk21) only update Docker Bake file but not Dockerfiles as JDK17 is still the default

### DIFF
--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -30,7 +30,7 @@ sources:
     spec:
       versionfilter:
         kind: regex
-        pattern: {{ .temurin.version_pattern }}
+        pattern: '{{ .temurin.version_pattern }}'
     transformers:
       - trimprefix: "jdk-"
       - replacer:
@@ -76,26 +76,6 @@ targets:
     spec:
       file: docker-bake.hcl
       path: variable.JAVA21_VERSION.default
-    scmid: default
-  setJDK21VersionAlpine:
-    name: "Bump JDK21 default ARG version on Alpine Dockerfile"
-    kind: dockerfile
-    sourceid: jdk21LastVersion
-    spec:
-      file: alpine/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK21VersionDebian:
-    name: "Bump JDK21 default ARG version on Debian Dockerfile"
-    kind: dockerfile
-    sourceid: jdk21LastVersion
-    spec:
-      file: debian/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
     scmid: default
 
 actions:


### PR DESCRIPTION
Related to #375

This PR ensure that the updatecli process, when upgrading the JDK21 version, does NOT change the default value in the `Dockerfile`s (see https://github.com/jenkinsci/docker-ssh-agent/pull/375#pullrequestreview-1954541927).

Once this PR is merged, we must close #375 and delete its source branch to ensure `updatecli` opens a new PR to bump JDK21 version.