### PR TITLE
breaking(Linux): short tags targeting Java 17 instead of Java 11

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -94,13 +94,10 @@ target "alpine_jdk11" {
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk11" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk11" : "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}",
     "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}",
   ]
   platforms = ["linux/amd64"]
 }
@@ -115,9 +112,12 @@ target "alpine_jdk17" {
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk17" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk17" : "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}",
     "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk17",
   ]
   platforms = ["linux/amd64"]
@@ -149,12 +149,10 @@ target "debian_jdk11" {
     DEBIAN_RELEASE = DEBIAN_RELEASE
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk11" : "",
     "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:debian-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
@@ -170,10 +168,12 @@ target "debian_jdk17" {
     DEBIAN_RELEASE = DEBIAN_RELEASE
   }
   tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk17" : "",
     "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:debian-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,7 +77,7 @@ variable "DEBIAN_RELEASE" {
 }
 
 variable "default_jdk" {
-  default = 11
+  default = 17
 }
 
 # Return "true" if the jdk passed as parameter is the same as the default jdk, "false" otherwise


### PR DESCRIPTION
This PR changes the short tags to target Java 17 (current default JDK version for Jenkins) instead of Java 11.

The Windows images short tags are already JDK17 ones.

Concerned short tags (3 Alpine and 2 Debian):
- "docker.io/jenkins/ssh-agent:alpine"
- "docker.io/jenkins/ssh-agent:alpine3.19"
- "docker.io/jenkins/ssh-agent:latest-alpine3.19"
- "docker.io/jenkins/ssh-agent:latest"
- "docker.io/jenkins/ssh-agent:\<version\>"

Closes:
- https://github.com/jenkinsci/docker-ssh-agent/issues/399

### Testing done

Compared the output of `docker buildx bake --file docker-bake.hcl linux --print` with `VERSION=1.2.3` & `ON_TAG=true`:

<details><summary>Before</summary>

```
{
  "group": {
    "default": {
      "targets": [
        "linux"
      ]
    },
    "linux": {
      "targets": [
        "alpine_jdk11",
        "alpine_jdk17",
        "alpine_jdk21",
        "debian_jdk11",
        "debian_jdk17",
        "debian_jdk21",
        "debian_jdk21-preview"
      ]
    }
  },
  "target": {
    "alpine_jdk11": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:alpine3.19",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk17": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:alpine-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "debian_jdk11": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3",
        "docker.io/jenkins/ssh-agent:1.2.3-jdk11",
        "docker.io/jenkins/ssh-agent:bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:debian-jdk11",
        "docker.io/jenkins/ssh-agent:jdk11",
        "docker.io/jenkins/ssh-agent:latest",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk11",
        "docker.io/jenkins/ssh-agent:latest-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/s390x",
        "linux/ppc64le"
      ]
    },
    "debian_jdk17": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk17",
        "docker.io/jenkins/ssh-agent:bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:debian-jdk17",
        "docker.io/jenkins/ssh-agent:jdk17",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk17",
        "docker.io/jenkins/ssh-agent:latest-jdk17"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "debian_jdk21": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:debian-jdk21",
        "docker.io/jenkins/ssh-agent:jdk21",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21",
        "docker.io/jenkins/ssh-agent:latest-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ]
    },
    "debian_jdk21-preview": {
      "context": ".",
      "dockerfile": "debian/preview/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.1+12"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21-preview",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-jdk21-preview"
      ],
      "platforms": [
        "linux/arm/v7"
      ]
    }
  }
}

```

</details>

<details><summary>After</summary>

```
{
  "group": {
    "default": {
      "targets": [
        "linux"
      ]
    },
    "linux": {
      "targets": [
        "alpine_jdk11",
        "alpine_jdk17",
        "alpine_jdk21",
        "debian_jdk11",
        "debian_jdk17",
        "debian_jdk21",
        "debian_jdk21-preview"
      ]
    }
  },
  "target": {
    "alpine_jdk11": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:alpine-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk11"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk17": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:alpine3.19",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "debian_jdk11": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk11",
        "docker.io/jenkins/ssh-agent:bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:debian-jdk11",
        "docker.io/jenkins/ssh-agent:jdk11",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk11",
        "docker.io/jenkins/ssh-agent:latest-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/s390x",
        "linux/ppc64le"
      ]
    },
    "debian_jdk17": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3",
        "docker.io/jenkins/ssh-agent:1.2.3-jdk17",
        "docker.io/jenkins/ssh-agent:bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:debian-jdk17",
        "docker.io/jenkins/ssh-agent:jdk17",
        "docker.io/jenkins/ssh-agent:latest",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk17",
        "docker.io/jenkins/ssh-agent:latest-jdk17"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "debian_jdk21": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:debian-jdk21",
        "docker.io/jenkins/ssh-agent:jdk21",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21",
        "docker.io/jenkins/ssh-agent:latest-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ]
    },
    "debian_jdk21-preview": {
      "context": ".",
      "dockerfile": "debian/preview/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.1+12"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21-preview",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-jdk21-preview"
      ],
      "platforms": [
        "linux/arm/v7"
      ]
    }
  }
}

```

</details>

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
