### PR TITLE
chore(Linux): factorise jdk in docker-bake.hcl

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -81,7 +81,7 @@ variable "default_jdk" {
 }
 
 # Return "true" if the jdk passed as parameter is the same as the default jdk, "false" otherwise
-function "short_tag" {
+function "is_default_jdk" {
   params = [jdk]
   result = equal(default_jdk, jdk) ? "true" : "false"
 }
@@ -128,15 +128,15 @@ target "alpine" {
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk${jdk}" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk${jdk}" : "",
     # If the jdk is the default one, add Alpine short tags
-    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine" : "",
-    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}" : "",
-    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}" : "",
+    is_default_jdk(jdk) ? "${REGISTRY}/${JENKINS_REPO}:alpine" : "",
+    is_default_jdk(jdk) ? "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}" : "",
+    is_default_jdk(jdk) ? "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}" : "",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
   ]
-  platforms = alpine_platforms("${jdk}")
+  platforms = alpine_platforms(jdk)
 }
 
 target "debian" {
@@ -154,9 +154,9 @@ target "debian" {
     # If there is a tag, add versioned tag suffixed by the jdk
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk${jdk}" : "",
     # If there is a tag and if the jdk is the default one, add versioned short tag
-    equal(ON_TAG, "true") ? (equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "") : "",
+    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "") : "",
     # If the jdk is the default one, add latest short tag
-    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
+    is_default_jdk(jdk) ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
     "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:debian-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:jdk${jdk}",
@@ -164,7 +164,7 @@ target "debian" {
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk${jdk}",
   ]
-  platforms = debian_platforms("${jdk}")
+  platforms = debian_platforms(jdk)
 }
 
 target "debian_jdk21-preview" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,20 +1,14 @@
 group "linux" {
   targets = [
-    "alpine_jdk11",
-    "alpine_jdk17",
-    "alpine_jdk21",
-    "debian_jdk11",
-    "debian_jdk17",
-    "debian_jdk21",
+    "alpine",
+    "debian",
     "debian_jdk21-preview",
   ]
 }
 
 group "linux-arm64" {
   targets = [
-    "debian_jdk11",
-    "debian_jdk17",
-    "debian_jdk21",
+    "debian",
     "alpine_jdk21",
   ]
 }
@@ -34,9 +28,7 @@ group "linux-s390x" {
 
 group "linux-ppc64le" {
   targets = [
-    "debian_jdk11",
-    "debian_jdk17",
-    "debian_jdk21"
+    "debian"
   ]
 }
 
@@ -84,120 +76,98 @@ variable "DEBIAN_RELEASE" {
   default = "bookworm-20240423"
 }
 
-target "alpine_jdk11" {
+variable "default_jdk" {
+  default = 17
+}
+
+# Return "true" if the jdk passed as parameter is the same as the default jdk, "false" otherwise
+function "short_tag" {
+  params = [jdk]
+  result = equal(default_jdk, jdk) ? "true" : "false"
+}
+
+# Return the complete Java version corresponding to the jdk passed as parameter
+function "javaversion" {
+  params = [jdk]
+  result = (equal(11, jdk)
+    ? "${JAVA11_VERSION}"
+    : (equal(17, jdk)
+      ? "${JAVA17_VERSION}"
+      : "${JAVA21_VERSION}")
+  )
+}
+
+# Return an array of Alpine platforms to use depending on the jdk passed as parameter
+function "alpine_platform" {
+  params = [jdk]
+  result = (equal(21, jdk)
+    ? ["linux/amd64", "linux/arm64"]
+    : ["linux/amd64"]
+  )
+}
+
+# Return an array of Debian platforms to use depending on the jdk passed as parameter
+function "debian_platform" {
+  params = [jdk]
+  result = (equal(17, jdk)
+    ? ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+    : ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  )
+}
+
+target "alpine" {
+  matrix = {
+    jdk = [11, 17, 21]
+  }
+  name       = "alpine_${jdk}"
   dockerfile = "alpine/Dockerfile"
   context    = "."
   args = {
     ALPINE_TAG   = ALPINE_FULL_TAG
-    JAVA_VERSION = JAVA11_VERSION
+    JAVA_VERSION = "${javaversion(jdk)}"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk11" : "",
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk11" : "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}",
-    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}",
+    # If there is a tag, add the versioned tags
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk${jdk}" : "",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk${jdk}" : "",
+    # If the jdk is the default one, add Alpine short tags
+    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine" : "",
+    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}" : "",
+    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}" : "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
   ]
-  platforms = ["linux/amd64"]
+  platforms = alpine_platform("${jdk}")
 }
 
-target "alpine_jdk17" {
-  dockerfile = "alpine/Dockerfile"
-  context    = "."
-  args = {
-    ALPINE_TAG   = ALPINE_FULL_TAG
-    JAVA_VERSION = JAVA17_VERSION
+target "debian" {
+  matrix = {
+    jdk = [11, 17, 21]
   }
-  tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk17" : "",
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk17" : "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk17",
-  ]
-  platforms = ["linux/amd64"]
-}
-
-target "alpine_jdk21" {
-  dockerfile = "alpine/Dockerfile"
-  context    = "."
-  args = {
-    ALPINE_TAG   = ALPINE_FULL_TAG
-    JAVA_VERSION = JAVA21_VERSION
-  }
-  tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk21" : "",
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk21" : "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk21",
-  ]
-  platforms = ["linux/amd64", "linux/arm64"]
-}
-
-target "debian_jdk11" {
+  name       = "debian_${jdk}"
   dockerfile = "debian/Dockerfile"
   context    = "."
   args = {
-    JAVA_VERSION   = JAVA11_VERSION
     DEBIAN_RELEASE = DEBIAN_RELEASE
+    JAVA_VERSION   = "${javaversion(jdk)}"
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "",
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk11" : "",
-    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:debian-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest",
-    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk11",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
+    # If there is a tag, add the versioned tag suffixed by the jdk
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk${jdk}" : "",
+    # If there is a tag and if the jdk is the default one, add the versioned short tag
+    equal(ON_TAG, "true") ? (equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "") : "",
+    # If the jdk is the default one, add latest short tag
+    equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
+    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:debian-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk${jdk}",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk${jdk}",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
-}
-
-target "debian_jdk17" {
-  dockerfile = "debian/Dockerfile"
-  context    = "."
-  args = {
-    JAVA_VERSION   = JAVA17_VERSION
-    DEBIAN_RELEASE = DEBIAN_RELEASE
-  }
-  tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk17" : "",
-    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:debian-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
-  ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
-}
-
-target "debian_jdk21" {
-  dockerfile = "debian/Dockerfile"
-  context    = "."
-  args = {
-    JAVA_VERSION   = JAVA21_VERSION
-    DEBIAN_RELEASE = DEBIAN_RELEASE
-  }
-  tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk21" : "",
-    "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:debian-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-bookworm-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk21",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk21",
-  ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }
 
 target "debian_jdk21-preview" {
@@ -208,6 +178,7 @@ target "debian_jdk21-preview" {
     DEBIAN_RELEASE = DEBIAN_RELEASE
   }
   tags = [
+    # If there is a tag, add the versioned tag suffixed by the jdk
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk21-preview" : "",
     "${REGISTRY}/${JENKINS_REPO}:bookworm-jdk21-preview",
     "${REGISTRY}/${JENKINS_REPO}:debian-jdk21-preview",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -93,26 +93,23 @@ function "javaversion" {
     ? "${JAVA11_VERSION}"
     : (equal(17, jdk)
       ? "${JAVA17_VERSION}"
-      : "${JAVA21_VERSION}")
-  )
+      : "${JAVA21_VERSION}"))
 }
 
 # Return an array of Alpine platforms to use depending on the jdk passed as parameter
-function "alpine_platform" {
+function "alpine_platforms" {
   params = [jdk]
   result = (equal(21, jdk)
     ? ["linux/amd64", "linux/arm64"]
-    : ["linux/amd64"]
-  )
+    : ["linux/amd64"])
 }
 
 # Return an array of Debian platforms to use depending on the jdk passed as parameter
-function "debian_platform" {
+function "debian_platforms" {
   params = [jdk]
   result = (equal(17, jdk)
     ? ["linux/amd64", "linux/arm64", "linux/ppc64le"]
-    : ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
-  )
+    : ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"])
 }
 
 target "alpine" {
@@ -127,7 +124,7 @@ target "alpine" {
     JAVA_VERSION = "${javaversion(jdk)}"
   }
   tags = [
-    # If there is a tag, add the versioned tags
+    # If there is a tag, add versioned tags suffixed by the jdk
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine-jdk${jdk}" : "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-alpine${ALPINE_SHORT_TAG}-jdk${jdk}" : "",
     # If the jdk is the default one, add Alpine short tags
@@ -139,7 +136,7 @@ target "alpine" {
     "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
   ]
-  platforms = alpine_platform("${jdk}")
+  platforms = alpine_platforms("${jdk}")
 }
 
 target "debian" {
@@ -154,9 +151,9 @@ target "debian" {
     JAVA_VERSION   = "${javaversion(jdk)}"
   }
   tags = [
-    # If there is a tag, add the versioned tag suffixed by the jdk
+    # If there is a tag, add versioned tag suffixed by the jdk
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}-jdk${jdk}" : "",
-    # If there is a tag and if the jdk is the default one, add the versioned short tag
+    # If there is a tag and if the jdk is the default one, add versioned short tag
     equal(ON_TAG, "true") ? (equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:${VERSION}" : "") : "",
     # If the jdk is the default one, add latest short tag
     equal(short_tag(jdk), "true") ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
@@ -167,7 +164,7 @@ target "debian" {
     "${REGISTRY}/${JENKINS_REPO}:latest-debian-jdk${jdk}",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk${jdk}",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+  platforms = debian_platforms("${jdk}")
 }
 
 target "debian_jdk21-preview" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,7 +77,7 @@ variable "DEBIAN_RELEASE" {
 }
 
 variable "default_jdk" {
-  default = 17
+  default = 11
 }
 
 # Return "true" if the jdk passed as parameter is the same as the default jdk, "false" otherwise


### PR DESCRIPTION
This PR factorises the JDK in docker bake file, resulting in a more concise definition of images and ensuring tagging consistency, with one block defining Alpine images, another defining Debian images, and lastly the remaining one for the special Debian 21 preview image.

~I titled this PR "chore/breaking" as it depends:~
- ~If this PR is released first, it will be a breaking change as it will change the JDK of the short tags to Java 17, closing #399 and superseding #400~
- ~If this PR is released after #400, there will be no change to the resulting images and tags.~

EDIT: No longer a breaking change with https://github.com/jenkinsci/docker-ssh-agent/pull/401/commits/427788cf3a50b320b6b1af8fe4f5d95140db8e5b

Note that we can still target a single image even with this factorisation:
```
docker buildx bake --file docker-bake.hcl alpine_21 --print 
```
<details>

```
{
  "group": {
    "default": {
      "targets": [
        "alpine_21"
      ]
    }
  },
  "target": {
    "alpine_21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    }
  }
}

```

</details>

### Testing done

Verified that the output of `docker buildx bake --file docker-bake.hcl linux --print` with `VERSION=1.2.3` & `ON_TAG=true` is equivalent to the one of #400:

<details><summary>#400</summary>

```
{
  "group": {
    "default": {
      "targets": [
        "linux"
      ]
    },
    "linux": {
      "targets": [
        "alpine_jdk11",
        "alpine_jdk17",
        "alpine_jdk21",
        "debian_jdk11",
        "debian_jdk17",
        "debian_jdk21",
        "debian_jdk21-preview"
      ]
    }
  },
  "target": {
    "alpine_jdk11": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:alpine-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk11"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk17": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:alpine3.19",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "debian_jdk11": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk11",
        "docker.io/jenkins/ssh-agent:bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:debian-jdk11",
        "docker.io/jenkins/ssh-agent:jdk11",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk11",
        "docker.io/jenkins/ssh-agent:latest-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/s390x",
        "linux/ppc64le"
      ]
    },
    "debian_jdk17": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3",
        "docker.io/jenkins/ssh-agent:1.2.3-jdk17",
        "docker.io/jenkins/ssh-agent:bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:debian-jdk17",
        "docker.io/jenkins/ssh-agent:jdk17",
        "docker.io/jenkins/ssh-agent:latest",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk17",
        "docker.io/jenkins/ssh-agent:latest-jdk17"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "debian_jdk21": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:debian-jdk21",
        "docker.io/jenkins/ssh-agent:jdk21",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21",
        "docker.io/jenkins/ssh-agent:latest-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ]
    },
    "debian_jdk21-preview": {
      "context": ".",
      "dockerfile": "debian/preview/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.1+12"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21-preview",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-jdk21-preview"
      ],
      "platforms": [
        "linux/arm/v7"
      ]
    }
  }
}
```

</details>

<details><summary>After</summary>

```
{
  "group": {
    "alpine": {
      "targets": [
        "alpine_11",
        "alpine_17",
        "alpine_21"
      ]
    },
    "debian": {
      "targets": [
        "debian_11",
        "debian_17",
        "debian_21"
      ]
    },
    "default": {
      "targets": [
        "linux"
      ]
    },
    "linux": {
      "targets": [
        "alpine",
        "debian",
        "debian_jdk21-preview"
      ]
    }
  },
  "target": {
    "alpine_11": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:alpine-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk11",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk11",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk11"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_17": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine3.19",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19",
        "docker.io/jenkins/ssh-agent:alpine-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk17",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk17",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.19.1",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:1.2.3-alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.19-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.19-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "debian_11": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "11.0.23_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk11",
        "docker.io/jenkins/ssh-agent:bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:debian-jdk11",
        "docker.io/jenkins/ssh-agent:jdk11",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk11",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk11",
        "docker.io/jenkins/ssh-agent:latest-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ]
    },
    "debian_17": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "17.0.11_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk17",
        "docker.io/jenkins/ssh-agent:1.2.3",
        "docker.io/jenkins/ssh-agent:latest",
        "docker.io/jenkins/ssh-agent:bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:debian-jdk17",
        "docker.io/jenkins/ssh-agent:jdk17",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk17",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk17",
        "docker.io/jenkins/ssh-agent:latest-jdk17"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "debian_21": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.3_9"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:debian-jdk21",
        "docker.io/jenkins/ssh-agent:jdk21",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21",
        "docker.io/jenkins/ssh-agent:latest-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ]
    },
    "debian_jdk21-preview": {
      "context": ".",
      "dockerfile": "debian/preview/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "bookworm-20240423",
        "JAVA_VERSION": "21.0.1+12"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:1.2.3-jdk21-preview",
        "docker.io/jenkins/ssh-agent:bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-bookworm-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-debian-jdk21-preview",
        "docker.io/jenkins/ssh-agent:latest-jdk21-preview"
      ],
      "platforms": [
        "linux/arm/v7"
      ]
    }
  }
}

```

</details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
