### PR TITLE
Bump OpenSSH to v9.5.0.0p1-beta and fix its installation on nanoserver

### DIFF
--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -92,8 +92,10 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive c:/openssh.zip 'C:/Program Files' ; `
     Remove-Item C:/openssh.zip ; `
     $env:PATH = '{0};{1}' -f $env:PATH,'C:\Program Files\OpenSSH-Win64' ; `
-    & 'C:/Program Files/OpenSSH-Win64/Install-SSHd.ps1' ; `
     if(!(Test-Path 'C:\ProgramData\ssh')) { New-Item -Type Directory -Path 'C:\ProgramData\ssh' | Out-Null } ; `
+    icacls 'C:\ProgramData\ssh' /inheritance:d ; `
+    icacls 'C:\ProgramData\ssh' /remove 'CREATOR OWNER' ; `
+    & 'C:/Program Files/OpenSSH-Win64/Install-SSHd.ps1' ; `
     Copy-Item 'C:\Program Files\OpenSSH-Win64\sshd_config_default' 'C:\ProgramData\ssh\sshd_config' ; `
     $content = Get-Content -Path "C:\ProgramData\ssh\sshd_config" ; `
     $content | ForEach-Object { $_ -replace '#PermitRootLogin.*','PermitRootLogin no' `

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -84,7 +84,7 @@ ENV JENKINS_AGENT_USER ${user}
 ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
 
 # Setup SSH server
-ARG OPENSSH_VERSION=V8.6.0.0p1-Beta
+ARG OPENSSH_VERSION=v9.5.0.0p1-Beta
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/{0}/OpenSSH-Win64.zip' -f $env:OPENSSH_VERSION ; `
     Write-Host "Retrieving $url..." ; `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -72,7 +72,7 @@ RUN $CurrentPath = (Get-Itemproperty -path 'hklm:\system\currentcontrolset\contr
     & C:\mingit\cmd\git.exe lfs install
 
 # Setup SSH server
-ARG OPENSSH_VERSION=V8.6.0.0p1-Beta
+ARG OPENSSH_VERSION=v9.5.0.0p1-Beta
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/{0}/OpenSSH-Win64.zip' -f $env:OPENSSH_VERSION ; `
     Write-Host "Retrieving $url..." ; `


### PR DESCRIPTION
This PR bumps OpenSSH to v9.5.0.0p1-beta and fixes its installation on nanoserver by removing the "CREATOR OWNER" from C:\ProgramData\ssh ACLs.

Ref:
- https://github.com/jenkinsci/docker-ssh-agent/pull/388#issuecomment-2084899297

Fixes:
- #302

Supersedes:
- #388 

Related:
- https://github.com/PowerShell/Win32-OpenSSH/issues/2017

### Testing done

Local tests + CI

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
