### PR TITLE
chore: jlink improvements from jenkinsci/docker

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,22 +24,21 @@ ARG JAVA_VERSION=17.0.11_9
 ARG ALPINE_TAG=3.19.1
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
-RUN if [ "$TARGETPLATFORM" != 'linux/arm/v7' ]; then \
-    case "$(jlink --version 2>&1)" in \
+RUN case "$(jlink --version 2>&1)" in \
       # jlink version 11 has less features than JDK17+
-      "11."*) strip_java_debug_flags="--strip-debug" ;; \
-      *) strip_java_debug_flags="--strip-java-debug-attributes" ;; \
+      "11."*) set -- "--strip-debug" "--compress=2" ;; \
+      "17."*) set -- "--strip-java-debug-attributes" "--compress=2" ;; \
+      # the compression argument is different for JDK21
+      "21."*) set -- "--strip-java-debug-attributes" "--compress=zip-6" ;; \
+      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
+      "$1" \
+      "$2" \
       --add-modules ALL-MODULE-PATH \
-      "$strip_java_debug_flags" \
       --no-man-pages \
       --no-header-files \
-      --compress=2 \
-      --output /javaruntime; \
-  else \
-    cp -r /opt/java/openjdk /javaruntime; \
-  fi
+      --output /javaruntime
 
 FROM alpine:"${ALPINE_TAG}" AS build
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -11,27 +11,21 @@ SHELL ["/bin/bash","-e", "-u", "-o", "pipefail", "-c"]
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
-    case "$(jlink --version 2>/dev/null)" in \
-        # jlink version 11 has less features than JDK17+
-        "11."*) strip_java_debug_flags=("--strip-debug") ;; \
-        *) strip_java_debug_flags=("--strip-java-debug-attributes") ;; \
+RUN case "$(jlink --version 2>&1)" in \
+      # jlink version 11 has less features than JDK17+
+      "11."*) set -- "--strip-debug" "--compress=2" ;; \
+      "17."*) set -- "--strip-java-debug-attributes" "--compress=2" ;; \
+      # the compression argument is different for JDK21
+      "21."*) set -- "--strip-java-debug-attributes" "--compress=zip-6" ;; \
+      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
-    if test "${TARGETPLATFORM}" != 'linux/amd/64'; then \
-        # posix_spawn (default for JDK12+) fails erratically with qemu on non x86 CPUs - https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
-        export JAVA_TOOL_OPTIONS='-Djdk.lang.Process.launchMechanism=vfork'; \
-    fi; \
     jlink \
-        --add-modules ALL-MODULE-PATH \
-        "${strip_java_debug_flags[@]}" \
-        --no-man-pages \
-        --no-header-files \
-        --compress=2 \
-        --output /javaruntime; \
-    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
-    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
-    else cp -r /opt/java/openjdk /javaruntime; \
-    fi
+      "$1" \
+      "$2" \
+      --add-modules ALL-MODULE-PATH \
+      --no-man-pages \
+      --no-header-files \
+      --output /javaruntime
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/debian/preview/Dockerfile
+++ b/debian/preview/Dockerfile
@@ -20,30 +20,9 @@ RUN apt-get update \
 
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
-    case "$(jlink --version 2>/dev/null)" in \
-        # jlink version 11 has less features than JDK17+
-        "11."*) strip_java_debug_flags=("--strip-debug") ;; \
-        *) strip_java_debug_flags=("--strip-java-debug-attributes") ;; \
-    esac; \
-    if test "${TARGETPLATFORM}" != 'linux/amd/64'; then \
-        # posix_spawn (default for JDK12+) fails erratically with qemu on non x86 CPUs - https://github.com/openzipkin/docker-java/issues/34#issuecomment-721673618
-        export JAVA_TOOL_OPTIONS='-Djdk.lang.Process.launchMechanism=vfork'; \
-    fi; \
-    jlink \
-        --add-modules ALL-MODULE-PATH \
-        "${strip_java_debug_flags[@]}" \
-        --no-man-pages \
-        --no-header-files \
-        --compress=2 \
-        --output /javaruntime; \
-    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
-    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
-    else cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
-    fi
+# It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
+# Because jlink fails with the error "jmods: Value too large for defined data type" error.
+RUN cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/debian/preview/Dockerfile
+++ b/debian/preview/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
 # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
 # Because jlink fails with the error "jmods: Value too large for defined data type" error.
-RUN cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+RUN cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime
 
 FROM debian:"${DEBIAN_RELEASE}"
 


### PR DESCRIPTION
This PR integrates jlink improvement from https://github.com/jenkinsci/docker/pull/1857.

Notes:
- I removed the TARGETPLATFORM check in Alpine and Debian images as we're not publishing any arm/v7 image of this kind.
- The Debian 21 "preview" Dockerfile has been modified to not use jlink as it's published only for arm/v7 architecture to avoid jlink's "jmods: Value too large for defined data type" error.

### Testing done

Local builds + CI

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
