### PR TITLE
chore: adapt updatecli jdk manifests for Windows

### DIFF
--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -79,6 +79,10 @@ targets:
     spec:
       file: build-windows.yaml
       key: $.services.jdk11.build.args.JAVA_VERSION
+    transformers:
+      - replacer:
+          from: _
+          to: +
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -79,6 +79,10 @@ targets:
     spec:
       file: build-windows.yaml
       key: $.services.jdk17.build.args.JAVA_VERSION
+    transformers:
+      - replacer:
+          from: _
+          to: +
     scmid: default
   setJDK17VersionAlpine:
     name: "Bump JDK17 default ARG version on Alpine Dockerfile"

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -84,6 +84,10 @@ targets:
     spec:
       file: build-windows.yaml
       key: $.services.jdk21.build.args.JAVA_VERSION
+    transformers:
+      - replacer:
+          from: _
+          to: +
     scmid: default
 
 actions:


### PR DESCRIPTION
This PR adapts updatecli jdk manifests for Windows by keeping the `+` in the JAVA_VERSION of the docker compose file.

Follow-up of:
- #404

Related pull requests that should contain no change:
- #408
- #409
- #410 

### Testing done


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->