### PR TITLE
fix: correct TEST_DEBUG retrieval in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,11 +19,8 @@ $Repository = 'ssh-agent'
 $Organisation = 'jenkins'
 $ImageType = 'windows-ltsc2019'
 
-$baseDockerCmd = 'docker-compose --file=build-windows.yaml'
-$baseDockerBuildCmd = '{0} build --parallel --pull' -f $baseDockerCmd
-
 if(![String]::IsNullOrWhiteSpace($env:TESTS_DEBUG)) {
-    $ImageType = $env:IMAGE_TYPE
+    $TestsDebug = $env:TESTS_DEBUG
 }
 $env:TESTS_DEBUG = $TestsDebug
 
@@ -84,10 +81,10 @@ function Test-Image {
         $ImageNameAndJavaVersion
     )
 
-    $items = $ImageNameAndJavaVersion.Split("|")
+    $items = $ImageNameAndJavaVersion.Split('|')
     $imageName = $items[0]
     $javaVersion = $items[1]
-    $imageNameItems = $imageName.Split(":")
+    $imageNameItems = $imageName.Split(':')
     $imageTag = $imageNameItems[1]
 
     Write-Host "= TEST: Testing ${ImageName} image"
@@ -119,15 +116,15 @@ function Test-Image {
 $baseDockerCmd = 'docker-compose --file=build-windows.yaml'
 $baseDockerBuildCmd = '{0} build --parallel --pull' -f $baseDockerCmd
 
-Write-Host "= PREPARE: List of $Organisation/$env:DOCKERHUB_REPO images and tags to be processed:"
+Write-Host "= PREPARE: List of images and tags to be processed:"
 Invoke-Expression "$baseDockerCmd config"
 
 Write-Host '= BUILD: Building all images...'
-    switch ($DryRun) {
-        $true { Write-Host "(dry-run) $baseDockerBuildCmd" }
-        $false { Invoke-Expression $baseDockerBuildCmd }
-    }
-    Write-Host '= BUILD: Finished building all images.'
+switch ($DryRun) {
+    $true { Write-Host "(dry-run) $baseDockerBuildCmd" }
+    $false { Invoke-Expression $baseDockerBuildCmd }
+}
+Write-Host '= BUILD: Finished building all images.'
 
 if($lastExitCode -ne 0) {
     exit $lastExitCode


### PR DESCRIPTION
This PR fixes a typo introduced in #396 preventing activating the debug of tests via (amongst others) an environment variable.

It also removes the duplicated declaration of the docker commands variables, lints the code by replacing double quotes around string without any variable by simple quotes so they're the same in all build.ps1 code, correctly reindents a small section of code and shortens an output log.

Extracted from:
- #415 

### Testing done

Local tests + CI

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
