### PR TITLE
chore: remove unused build.ps1 `Build` parameter and commented line

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,6 @@
 Param(
     [Parameter(Position=1)]
     [String] $Target = 'build',
-    [String] $Build = '',
     [String] $VersionTag = '1.0-1',
     [switch] $DryRun = $false,
     # Output debug info for tests. Accepted values:
@@ -97,7 +96,6 @@ function Test-Image {
         Remove-Item -Recurse -Force $targetPath
     }
     New-Item -Path $targetPath -Type Directory | Out-Null
-    # $configuration.Run.Path = 'tests\sshAgent.Tests.ps1'
     $configuration.TestResult.OutputPath = '{0}\junit-results.xml' -f $targetPath
     $TestResults = Invoke-Pester -Configuration $configuration
     $failed = $false

--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -1,7 +1,9 @@
 Import-Module -DisableNameChecking -Force $PSScriptRoot/test_helpers.psm1
 
-$global:IMAGE_NAME = Get-EnvOrDefault 'IMAGE_NAME' '' # Ex: jenkins4eval/ssh-agent:nanoserver-1809-jdk17
+$global:IMAGE_NAME = Get-EnvOrDefault 'IMAGE_NAME' '' # Ex: jenkins4eval/ssh-agent:nanoserver-ltsc2019-jdk17
 $global:JAVA_VERSION = Get-EnvOrDefault 'JAVA_VERSION' ''
+
+Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Java $global:JAVA_VERSION"
 
 $imageItems = $global:IMAGE_NAME.Split(':')
 $global:IMAGE_TAG = $imageItems[1]


### PR DESCRIPTION
This PR removes this unused build.ps1 `Build` parameter:
https://github.com/jenkinsci/docker-ssh-agent/blob/bad064233ecebab858236cd141e39b06b5fdbf98/build.ps1#L2-L5

And a commented line that I should have removed from https://github.com/jenkinsci/docker-ssh-agent/pull/289 when adapting from docker-agent build process (where setting this path is needed as there is a tests suite per type of agent):
https://github.com/jenkinsci/docker-ssh-agent/blob/bad064233ecebab858236cd141e39b06b5fdbf98/build.ps1#L100

### Testing done

Local test + CI

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
