### PR TITLE
hotfix(updatecli): remove docker compose target from manifests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -102,7 +102,7 @@ function "javaversion" {
       : "${JAVA21_VERSION}"))
 }
 
-# Specific functions
+## Specific functions
 # Return an array of Alpine platforms to use depending on the jdk passed as parameter
 function "alpine_platforms" {
   params = [jdk]

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -72,18 +72,6 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA11_VERSION.default
     scmid: default
-  setJDK11VersionDockerCompose:
-    name: "Bump JDK11 version for Windows images in the build-windows.yaml file"
-    kind: yaml
-    sourceid: jdk11LastVersion
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk11.build.args.JAVA_VERSION
-    transformers:
-      - replacer:
-          from: _
-          to: +
-    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -72,18 +72,6 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA17_VERSION.default
     scmid: default
-  setJDK17VersionDockerCompose:
-    name: "Bump JDK17 version for Windows images in the build-windows.yaml file"
-    kind: yaml
-    sourceid: jdk17LastVersion
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk17.build.args.JAVA_VERSION
-    transformers:
-      - replacer:
-          from: _
-          to: +
-    scmid: default
   setJDK17VersionAlpine:
     name: "Bump JDK17 default ARG version on Alpine Dockerfile"
     kind: dockerfile

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -77,18 +77,6 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA21_VERSION.default
     scmid: default
-  setJDK21VersionDockerCompose:
-    name: "Bump JDK21 version for Windows images in the build-windows.yaml file"
-    kind: yaml
-    sourceid: jdk21LastVersion
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk21.build.args.JAVA_VERSION
-    transformers:
-      - replacer:
-          from: _
-          to: +
-    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
This PR removes docker compose target from updatecli manifests as build-windows.yaml has been removed in #415.

Fixup of:
- #415 

### Testing done

```console
$ updatecli diff --values updatecli/values.github-action.yaml --values updatecli/values.temurin.yaml --config updatecli/updatecli.d/
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
