### PR TITLE
fix: pin windowsservercore-ltsc2019 to April 2024 release

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -141,6 +141,15 @@ function "toolsversion" {
     : version)
 }
 
+# Return the Windows version digest to use for windowsservercore ltsc2019 image
+# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
+function "windowsversiondigest" {
+  params = [version]
+  result = (equal("ltsc2019", version)
+    ? "@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4"
+    : "")
+}
+
 target "alpine" {
   matrix = {
     jdk = jdks_to_build
@@ -208,6 +217,8 @@ target "nanoserver" {
     JAVA_HOME = "C:/openjdk-${jdk}"
     JAVA_VERSION   = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
+    # TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
+    WINDOWS_VERSION_DIGEST = windowsversiondigest(windows_version)
     WINDOWS_VERSION_TAG = windows_version
   }
   tags = [
@@ -233,6 +244,8 @@ target "windowsservercore" {
     JAVA_HOME = "C:/openjdk-${jdk}"
     JAVA_VERSION   = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
+    # TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
+    WINDOWS_VERSION_DIGEST = windowsversiondigest(windows_version)
     WINDOWS_VERSION_TAG = windows_version
   }
   tags = [

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -24,7 +24,9 @@
 
 ARG WINDOWS_VERSION_TAG
 ARG TOOLS_WINDOWS_VERSION
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
+# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
+ARG WINDOWS_VERSION_DIGEST # Empty by default
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}" AS jdk-core
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -24,7 +24,9 @@
 
 ARG WINDOWS_VERSION_TAG
 ARG TOOLS_WINDOWS_VERSION
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
+# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
+ARG WINDOWS_VERSION_DIGEST # Empty by default
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}" AS jdk-core
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -38,7 +40,7 @@ RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
     $proc.WaitForExit() ; `
     Remove-Item -Path C:\temp -Recurse | Out-Null
 
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}"
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}"
 
 ARG JAVA_HOME
 ENV JAVA_HOME=${JAVA_HOME}


### PR DESCRIPTION
This PR applies the same fix as the docker-agent one:
- https://github.com/jenkinsci/docker-agent/pull/816

To be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved.

### Testing done

Local test

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
