### PR TITLE
Revert "fix: pin windowsservercore-ltsc2019 to April 2024 release"

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -141,15 +141,6 @@ function "toolsversion" {
   : version)
 }
 
-# Return the Windows version digest to use for windowsservercore ltsc2019 image
-# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
-function "windowsversiondigest" {
-  params = [version]
-  result = (equal("ltsc2019", version)
-    ? "@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4"
-    : "")
-}
-
 target "alpine" {
   matrix = {
     jdk = jdks_to_build
@@ -217,9 +208,7 @@ target "nanoserver" {
     JAVA_HOME             = "C:/openjdk-${jdk}"
     JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
-    # TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
-    WINDOWS_VERSION_DIGEST = windowsversiondigest(windows_version)
-    WINDOWS_VERSION_TAG    = windows_version
+    WINDOWS_VERSION_TAG   = windows_version
   }
   tags = [
     # If there is a tag, add versioned tag suffixed by the jdk
@@ -244,9 +233,7 @@ target "windowsservercore" {
     JAVA_HOME             = "C:/openjdk-${jdk}"
     JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
-    # TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
-    WINDOWS_VERSION_DIGEST = windowsversiondigest(windows_version)
-    WINDOWS_VERSION_TAG    = windows_version
+    WINDOWS_VERSION_TAG   = windows_version
   }
   tags = [
     # If there is a tag, add versioned tag suffixed by the jdk

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -24,9 +24,7 @@
 
 ARG WINDOWS_VERSION_TAG
 ARG TOOLS_WINDOWS_VERSION
-# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
-ARG WINDOWS_VERSION_DIGEST # Empty by default
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}" AS jdk-core
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -24,9 +24,7 @@
 
 ARG WINDOWS_VERSION_TAG
 ARG TOOLS_WINDOWS_VERSION
-# TODO: workaround, to be removed when https://github.com/microsoft/Windows-Containers/issues/493 is resolved
-ARG WINDOWS_VERSION_DIGEST # Empty by default
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}" AS jdk-core
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -40,7 +38,7 @@ RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
     $proc.WaitForExit() ; `
     Remove-Item -Path C:\temp -Recurse | Out-Null
 
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}${WINDOWS_VERSION_DIGEST}"
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}"
 
 ARG JAVA_HOME
 ENV JAVA_HOME=${JAVA_HOME}


### PR DESCRIPTION
Reverts jenkinsci/docker-ssh-agent#433

This PR removes the Windows Server Core version pinning so we can use its last image version published today as base instead of the one from April 2024.

From https://github.com/microsoft/Windows-Containers/issues/493#issuecomment-2219090926:

> The updated images released as part of the July 2024 security update today include the fix for this issue.

Confirmed by building this from another host than Windows:
```
# OK with docker buildx build --platform windows/amd64 -t test .
FROM --platform=windows/amd64 mcr.microsoft.com/windows/servercore:ltsc2019 AS latest
COPY README.md README.md

# OK with docker buildx build --platform windows/amd64 -t test .
FROM --platform=windows/amd64 mcr.microsoft.com/windows/servercore:ltsc2019@sha256:41f42aa4ad39d85e4d30642b8111ca6454ca2275f188f012934b9afbaf63a647 AS latestdigest
COPY README.md README.md
```

Same as:
- https://github.com/jenkinsci/docker-agent/pull/833

Ref:
- https://github.com/jenkinsci/docker-agent/issues/815#issuecomment-2219948971