### PR TITLE
Revert "chore(Jenkinsfile) avoid Docker API rate limit"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,16 +54,13 @@ pipeline {
                                 }
                                 steps {
                                     script {
-                                        // This function is defined in the jenkins-infra/pipeline-library
-                                        infra.withDockerCredentials {
-                                            if(isUnix()) {
-                                                sh 'make build'
-                                                sh 'make test'
-                                                // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
-                                                sh 'make every-build'
-                                            } else {
-                                                powershell '& ./build.ps1 test'
-                                            }
+                                        if(isUnix()) {
+                                            sh 'make build'
+                                            sh 'make test'
+                                            // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
+                                            sh 'make every-build'
+                                        } else {
+                                            powershell '& ./build.ps1 test'
                                         }
                                     }
                                 }


### PR DESCRIPTION
Reverts jenkinsci/docker-ssh-agent#442 as per https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2270821972 (we now have a DockerHub mirror)