### PR TITLE
debugging on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
     }
     post {
         always {
-            archiveArtifacts artifacts: 'build-windows.yaml', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'build-windows*.yaml', allowEmptyArchive: true
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         stage('docker-ssh-agent') {
             environment {
                 DOCKERHUB_ORGANISATION = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
+                TESTS_DEBUG = 'verbose'
             }
             matrix {
                 axes {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
                                     script {
                                         if(isUnix()) {
                                             sh 'make build'
-                                            sh 'make test'
+                                            sh 'make test || cat *.yaml'
                                             // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
                                             sh 'make every-build'
                                         } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,8 @@ pipeline {
                 axes {
                     axis {
                         name 'IMAGE_TYPE'
-                        values 'linux', 'nanoserver-1809', 'nanoserver-ltsc2019', 'nanoserver-ltsc2022', 'windowsservercore-ltsc2019', 'windowsservercore-ltsc2022'
+                        // values 'linux', 'nanoserver-1809', 'nanoserver-ltsc2019', 'nanoserver-ltsc2022', 'windowsservercore-ltsc2019', 'windowsservercore-ltsc2022'
+                        values 'nanoserver-ltsc2022'
                     }
                 }
                 stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                             label agentSelector(env.IMAGE_TYPE)
                         }
                         options {
-                            timeout(time: 60, unit: 'MINUTES')
+                            timeout(time: 120, unit: 'MINUTES')
                         }
                         stages {
                             stage('Prepare Docker') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,11 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            archiveArtifacts artifacts: 'build-windows.yaml', allowEmptyArchive: true
+        }
+    }
 }
 
 // vim: ft=groovy


### PR DESCRIPTION
This PR tries to find what's the issue with the build. (WIP)

Local testing on Windows is OK according to https://github.com/jenkins-infra/helpdesk/issues/4557#issuecomment-2685200351, and on Linux too.

Update 1:

Noticed an unexpected EOF (on nanoserver-ltsc2022_jdk17) in https://ci.jenkins.io/job/Packaging/job/docker-ssh-agent/view/change-requests/job/PR-493/1/execution/node/158/log/ that was not present in last successful jobs like https://ci.jenkins.io/job/Packaging/job/docker-ssh-agent/view/change-requests/job/PR-478/17/execution/node/149/log/.

> 22:00:03  Successfully built 68fb9fe7a3e6
> 22:00:03  Successfully tagged jenkins/ssh-agent:nanoserver-ltsc2022-jdk17
> 22:00:03   Service nanoserver-ltsc2022_jdk17  Built
> 22:00:35  unexpected EOF
> 22:00:35  = BUILD: Finished building all images.

Curiously, other Windows flavors from the same build have been built without issue.

Added the archival of build-windows.yaml to check it.

Update 2:

Build #2 also has this unexpected EOF (on windowsservercore-ltsc2022_jdk21): https://ci.jenkins.io/job/Packaging/job/docker-ssh-agent/view/change-requests/job/PR-493/2/execution/node/162/log/

(OK on windowsservercore-ltsc2022_jdk17 in build #1 at https://ci.jenkins.io/job/Packaging/job/docker-ssh-agent/view/change-requests/job/PR-493/1/execution/node/162/log/, doesn't seem directly related to ltsc2022)

Update 3:

Most Windows branches seem stuck on "Describing [jenkins/ssh-agent:\<flavor>] create agent container with pubkey as argument" test.

Related:
- https://github.com/jenkins-infra/helpdesk/issues/4557

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
