### PR TITLE
chore: use TOML config with buildx to avoid DockerHub rate limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,16 @@ check-reqs:
 
 ## This function is specific to Jenkins infrastructure and isn't required in other contexts
 docker-init: check-reqs
-	@set -x; docker buildx create --use
+ifeq ($(CI),true)
+ifeq ($(wildcard /etc/buildkitd.toml),)
+	echo 'WARNING: /etc/buildkitd.toml not found, using default configuration.'
+	docker buildx create --use --bootstrap --driver docker-container
+else
+	docker buildx create --use --bootstrap --driver docker-container --config /etc/buildkitd.toml
+endif
+else
+	docker buildx create --use --bootstrap --driver docker-container
+endif
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 build: check-reqs


### PR DESCRIPTION
This PR uses TOM config with buildx if executed on CI and if `/etc/buildkitd.toml` file exists to use registry mirrors.

Supersedes and closes #497 

Similar to:
- https://github.com/jenkinsci/docker-agent/pull/958

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4585#issuecomment-2751406309
- https://github.com/jenkins-infra/jenkins-infra/pull/3938
- https://docs.docker.com/build/buildkit/configure/#registry-mirror

### Testing done

`make docker-init` + CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
