### PR TITLE
chore: fix warnings from buildx checks (`FromAsCasing` and `LegacyKeyValueFormat`)

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 ARG DEBIAN_RELEASE=bookworm-20250317
-FROM debian:"${DEBIAN_RELEASE}"-slim as jre-build
+FROM debian:"${DEBIAN_RELEASE}"-slim AS jre-build
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -91,8 +91,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 
 ARG user=jenkins
 ARG JENKINS_AGENT_WORK="C:/Users/${user}/Work"
-ENV JENKINS_AGENT_USER ${user}
-ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
+ENV JENKINS_AGENT_USER=${user}
+ENV JENKINS_AGENT_WORK=${JENKINS_AGENT_WORK}
 
 # Setup SSH server
 ARG OPENSSH_VERSION=v9.8.1.0p1-Preview

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -49,8 +49,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG user=jenkins
 ARG JENKINS_AGENT_WORK="C:/Users/${user}/Work"
-ENV JENKINS_AGENT_USER ${user}
-ENV JENKINS_AGENT_WORK ${JENKINS_AGENT_WORK}
+ENV JENKINS_AGENT_USER=${user}
+ENV JENKINS_AGENT_WORK=${JENKINS_AGENT_WORK}
 
 USER ContainerAdministrator
 


### PR DESCRIPTION
Same as https://github.com/jenkinsci/docker-agent/pull/965