### PR TITLE
Revert "Revert "chore: disable failing test(s) until jenkins-infra/helpdesk#4557 infra issue is resolved""

### DIFF
--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -148,76 +148,69 @@ Describe "[$global:IMAGE_NAME] image has correct version of java and git-lfs ins
     }
 }
 
-Describe "[$global:IMAGE_NAME] create agent container with pubkey as argument" {
-    BeforeAll {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all `"$global:IMAGE_NAME`" `"$global:PUBLIC_SSH_KEY`""
-        $exitCode | Should -Be 0
-        Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
-        Start-Sleep -Seconds 10
-    }
+# TODO: restore when https://github.com/jenkins-infra/helpdesk/issues/4557 infra issue is resolved
+# Describe "[$global:IMAGE_NAME] create agent container with pubkey as argument" {
+#     BeforeAll {
+#         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all `"$global:IMAGE_NAME`" `"$global:PUBLIC_SSH_KEY`""
+#         $exitCode | Should -Be 0
+#         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
+#         Start-Sleep -Seconds 10
+#     }
 
-    It 'can check running containers' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "container ls"
-        $exitCode | Should -Be 0
-    }
+#     It 'runs commands via ssh' {
+#         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
+#         $exitCode | Should -Be 0
+#         $stdout | Should -Match 'f00'
+#     }
 
-    It 'can get logs of running container' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "logs `"$global:CONTAINERNAME`""
-        $exitCode | Should -Be 0
-    }
+#     AfterAll {
+#         Cleanup($global:CONTAINERNAME)
+#     }
+# }
 
-    It 'runs commands via ssh' {
-        $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
-        $exitCode | Should -Be 0
-        $stdout | Should -Match 'f00'
-    }
+# TODO: restore when https://github.com/jenkins-infra/helpdesk/issues/4557 infra issue is resolved
+# Describe "[$global:IMAGE_NAME] create agent container with pubkey as envvar" {
+#     BeforeAll {
+#         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all `"$global:IMAGE_NAME`" `"$global:PUBLIC_SSH_KEY`""
+#         $exitCode | Should -Be 0
+#         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
+#         Start-Sleep -Seconds 10
+#     }
 
-    AfterAll {
-        Cleanup($global:CONTAINERNAME)
-    }
-}
+#     It 'runs commands via ssh' {
+#         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
+#         $exitCode | Should -Be 0
+#         $stdout | Should -Match 'f00'
+#         Start-Sleep -Seconds 10
+#     }
 
-Describe "[$global:IMAGE_NAME] create agent container with pubkey as envvar" {
-    BeforeAll {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all `"$global:IMAGE_NAME`" `"$global:PUBLIC_SSH_KEY`""
-        $exitCode | Should -Be 0
-        Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
-        Start-Sleep -Seconds 10
-    }
-
-    It 'runs commands via ssh' {
-        $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
-        $exitCode | Should -Be 0
-        $stdout | Should -Match 'f00'
-        Start-Sleep -Seconds 10
-    }
-
-    AfterAll {
-        Cleanup($global:CONTAINERNAME)
-    }
-}
+#     AfterAll {
+#         Cleanup($global:CONTAINERNAME)
+#     }
+# }
 
 
-$global:DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
-Describe "[$global:IMAGE_NAME] create agent container like docker-plugin with '$global:DOCKER_PLUGIN_DEFAULT_ARG' as argument" {
-    BeforeAll {
-        [string]::IsNullOrWhiteSpace($global:DOCKER_PLUGIN_DEFAULT_ARG) | Should -BeFalse
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all --env=`"JENKINS_AGENT_SSH_PUBKEY=$global:PUBLIC_SSH_KEY`" `"$global:IMAGE_NAME`" `"$global:DOCKER_PLUGIN_DEFAULT_ARG`""
-        $exitCode | Should -Be 0
-        Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
-        Start-Sleep -Seconds 10
-    }
+# TODO: restore when https://github.com/jenkins-infra/helpdesk/issues/4557 infra issue is resolved
+# $global:DOCKER_PLUGIN_DEFAULT_ARG="/usr/sbin/sshd -D -p 22"
+# Describe "[$global:IMAGE_NAME] create agent container like docker-plugin with '$global:DOCKER_PLUGIN_DEFAULT_ARG' as argument" {
+#     BeforeAll {
+#         [string]::IsNullOrWhiteSpace($global:DOCKER_PLUGIN_DEFAULT_ARG) | Should -BeFalse
+#         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all --env=`"JENKINS_AGENT_SSH_PUBKEY=$global:PUBLIC_SSH_KEY`" `"$global:IMAGE_NAME`" `"$global:DOCKER_PLUGIN_DEFAULT_ARG`""
+#         $exitCode | Should -Be 0
+#         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
+#         Start-Sleep -Seconds 10
+#     }
 
-    It 'runs commands via ssh' {
-        $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
-        $exitCode | Should -Be 0
-        $stdout | Should -Match 'f00'
-    }
+#     It 'runs commands via ssh' {
+#         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
+#         $exitCode | Should -Be 0
+#         $stdout | Should -Match 'f00'
+#     }
 
-    AfterAll {
-        Cleanup($global:CONTAINERNAME)
-    }
-}
+#     AfterAll {
+#         Cleanup($global:CONTAINERNAME)
+#     }
+# }
 
 Describe "[$global:IMAGE_NAME] build args" {
     BeforeAll {


### PR DESCRIPTION
Reverts jenkinsci/docker-ssh-agent#496

Same as #495 by @lemeurherveCB  since we are [back to AW for ci.jenkins.io](https://github.com/jenkins-infra/helpdesk/issues/4688).

As a reminder: we tried on an agent with an interactive session and the test harness was passing.

Worth retrying again though to understand what is happening.
Most probably the test need to increases the pauses to handle the Windows slow machines.