### PR TITLE
feat(linux): add support on Linux for JDK 25 preview in Docker build configurations

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -44,18 +44,17 @@ RUN apk add --no-cache \
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac; \
-    jlink \
-      --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
-      --no-man-pages \
-      --no-header-files \
-      --output /javaruntime
+    "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
+    "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec ;; \
+    *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+  esac; \
+  jlink \
+    --strip-java-debug-attributes \
+    "$@" \
+    --no-man-pages \
+    --no-header-files \
+    --output /javaruntime
 
 FROM alpine:"${ALPINE_TAG}" AS build
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -46,18 +46,17 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
-      # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
-      *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
-    esac; \
-    jlink \
-      --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
-      --no-man-pages \
-      --no-header-files \
-      --output /javaruntime
+    "17."*) set -- "--compress=2" --add-modules ALL-MODULE-PATH ;; \
+    "21."*) set -- "--compress=zip-6" --add-modules ALL-MODULE-PATH ;; \
+    "25"*) set -- "--compress=zip-6" --add-modules java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec ;; \
+    *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
+  esac; \
+  jlink \
+    --strip-java-debug-attributes \
+    "$@" \
+    --no-man-pages \
+    --no-header-files \
+    --output /javaruntime
 
 FROM debian:"${DEBIAN_RELEASE}"
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,6 +32,10 @@ group "linux-ppc64le" {
 }
 
 variable "jdks_to_build" {
+  default = [17, 21, 25]
+}
+
+variable "jdks_to_build_windows" {
   default = [17, 21]
 }
 
@@ -71,6 +75,10 @@ variable "JAVA21_VERSION" {
   default = "21.0.8_9"
 }
 
+variable "JAVA25_VERSION" {
+  default = "25+9-ea-beta"
+}
+
 variable "DEBIAN_RELEASE" {
   default = "trixie-20250908"
 }
@@ -92,16 +100,18 @@ function "javaversion" {
   params = [jdk]
   result = (equal(17, jdk)
     ? "${JAVA17_VERSION}"
-  : "${JAVA21_VERSION}")
+  : equal(21, jdk)
+    ? "${JAVA21_VERSION}"
+  : "${JAVA25_VERSION}")
 }
 
 ## Specific functions
 # Return an array of Alpine platforms to use depending on the jdk passed as parameter
 function "alpine_platforms" {
   params = [jdk]
-  result = (equal(21, jdk)
-    ? ["linux/amd64", "linux/arm64"]
-  : ["linux/amd64"])
+  result = (equal(17, jdk)
+    ? ["linux/amd64"]
+    : ["linux/amd64", "linux/arm64"])
 }
 
 # Return an array of Debian platforms to use depending on the jdk passed as parameter
@@ -191,7 +201,7 @@ target "debian" {
 
 target "nanoserver" {
   matrix = {
-    jdk             = jdks_to_build
+    jdk             = jdks_to_build_windows
     windows_version = windowsversions("nanoserver")
   }
   name       = "nanoserver-${windows_version}_jdk${jdk}"
@@ -216,7 +226,7 @@ target "nanoserver" {
 
 target "windowsservercore" {
   matrix = {
-    jdk             = jdks_to_build
+    jdk             = jdks_to_build_windows
     windows_version = windowsversions("windowsservercore")
   }
   name       = "windowsservercore-${windows_version}_jdk${jdk}"


### PR DESCRIPTION
  - Add JDK25 version variable (25+9-ea-beta) to docker-bake.hcl
  - Update jlink configuration for JDK25 with specific modules
  - Create separate Windows JDK build matrix excluding JDK25
  - Support JDK25 on Alpine and Debian Linux platforms only

<!-- Please describe your pull request here. -->

### Testing done

`make build`
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
