### PR TITLE
chore(pipeline): split `Build and Test` stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,14 +88,20 @@ def parallelStages = [failFast: false]
                                 }
                             }
                         } else {
-                            stage('Build and Test') {
-                                // ci.jenkins.io builds (e.g. no publication)
+                            // ci.jenkins.io builds (e.g. no publication)
+                            stage('Build') {
                                 if (isUnix()) {
                                     sh 'make build'
+                                } else {
+                                    powershell '& ./build.ps1 build'
+                                    archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
+                                }
+                            }
+                            stage('Test') {
+                                if (isUnix()) {
                                     sh 'make test'
                                 } else {
                                     powershell '& ./build.ps1 test'
-                                    archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
                                 }
                                 junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
                             }

--- a/build.ps1
+++ b/build.ps1
@@ -168,15 +168,17 @@ if ((Test-Path $dockerComposeFile) -and -not $OverwriteDockerComposeFile) {
 Write-Host '= PREPARE: List of images and tags to be processed:'
 Invoke-Expression "$baseDockerCmd config"
 
-Write-Host '= BUILD: Building all images...'
-switch ($DryRun) {
-    $true { Write-Host "(dry-run) $baseDockerBuildCmd" }
-    $false { Invoke-Expression $baseDockerBuildCmd }
-}
-Write-Host '= BUILD: Finished building all images.'
+if ($target -eq 'build') {
+    Write-Host '= BUILD: Building all images...'
+    switch ($DryRun) {
+        $true { Write-Host "(dry-run) $baseDockerBuildCmd" }
+        $false { Invoke-Expression $baseDockerBuildCmd }
+    }
+    Write-Host '= BUILD: Finished building all images.'
 
-if($lastExitCode -ne 0) {
-    exit $lastExitCode
+    if($lastExitCode -ne 0) {
+        exit $lastExitCode
+    }
 }
 
 if($target -eq 'test') {


### PR DESCRIPTION
This PR splits the existing stage into "Build" and "Test".

Having separate stages allows a better understanding of the potential gains on each of those part when improving the building process.

Notes:
- Generated docker compose files are archived even if the tests fail
- As the `publish` target includes building the images, no need to call it first when only that one is running on trusted.ci.jenkins.io
- As there is no "test" phase for multi-arch build, no need to change it

Similar to:
- https://github.com/jenkinsci/docker-agent/pull/1071

### Testing done

- CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

PS: easier to review without whitespaces, see https://github.com/jenkinsci/docker-agent/pull/1071/files?diff=unified&w=1
