### PR TITLE
chore(windows): build before publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,7 @@ def parallelStages = [failFast: false]
                                         if (isUnix()) {
                                             sh 'make publish'
                                         } else {
+                                            powershell '& ./build.ps1 build'
                                             powershell '& ./build.ps1 publish'
                                         }
                                     }


### PR DESCRIPTION
This PR builds Windows images before publishing it.

Fixup of:
- #562

Noticed after checking recent Windows images in docker hub while working on:
- https://github.com/jenkinsci/docker/pull/2102

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
