### PR TITLE
chore(updatecli): check architectures availability in debian manifest

### DIFF
--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -16,7 +16,7 @@ scms:
 sources:
   trixieLatestVersion:
     kind: dockerimage
-    name: "Get the latest Debian Trixie Linux version"
+    name: "Get latest Debian Trixie Linux version"
     spec:
       image: "debian"
       tagfilter: "trixie-*"
@@ -25,9 +25,22 @@ sources:
         pattern: >-
           trixie-\d+$
 
+conditions:
+  checkArchitecturesAvailability:
+    kind: dockerimage
+    name: Check if container image is available for all architectures
+    sourceid: trixieLatestVersion
+    spec:
+      image: "debian"
+      architectures:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
+
 targets:
   updateDockerfile:
-    name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile"
+    name: "Update value of base image (ARG DEBIAN_RELEASE) in Dockerfile"
     kind: dockerfile
     sourceid: trixieLatestVersion
     spec:
@@ -37,7 +50,7 @@ targets:
         matcher: "DEBIAN_RELEASE"
     scmid: default
   updateDockerBake:
-    name: "Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl"
+    name: "Update default value of variable DEBIAN_RELEASE in docker-bake.hcl"
     kind: hcl
     sourceid: trixieLatestVersion
     spec:


### PR DESCRIPTION
This PR adds a condition to check if all architectures are available before opening a pull request to avoid premature builds.

Refs:
- https://github.com/jenkinsci/docker-ssh-agent/issues/570
- #568

### Testing done

```
$ updatecli diff --config ./updatecli/updatecli.d/debian.yaml --values updatecli/values.github-action.yaml 
```

<details>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/debian.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##############################
# BUMP DEBIAN TRIXIE VERSION #
##############################

source: source#trixieLatestVersion
--------------------------

Searching for version matching pattern "trixie-\\d+$"
✔ Docker Image Tag "trixie-20251103" found matching pattern "trixie-\\d+$"

condition: condition#checkUbi9DockerImage
------------------------------
✔ docker image debian:trixie-20251103 found

target: target#updateDockerfile
-----------------------

**Dry Run enabled**

✔ The line #22, matched by the keyword "ARG" and the matcher "DEBIAN_RELEASE", is correctly set to "ARG DEBIAN_RELEASE=trixie-20251103".
✔ - changed lines [] of file "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker-ssh-agent/debian/Dockerfile"

target: target#updateDockerBake
-----------------------

**Dry Run enabled**

✔ - no changes detected:
        path "variable.DEBIAN_RELEASE.default" already set to "trixie-20251103", from file "docker-bake.hcl", 


ACTIONS
========


Bump Debian Trixie version
  => Bump Debian Trixie Linux version to trixie-20251103

No follow up action needed

=============================

SUMMARY:



✔ Bump Debian Trixie version:
        Source:
                ✔ [trixieLatestVersion] Get the latest Debian Trixie Linux version
        Condition:
                ✔ [checkArchitecturesAvailability] Check if the container image is available
        Target:
                ✔ [updateDockerBake] Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl
                ✔ [updateDockerfile] Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
