### PR TITLE
chore: reorder Windows tests and improve their descriptions

### DIFF
--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -208,7 +208,7 @@ Describe "[$global:IMAGE_TAG] image can be built" {
     }
 }
 
-Describe "[$global:IMAGE_TAG] build args" {
+Describe "[$global:IMAGE_TAG] image can be built with custom build args" {
     BeforeAll {
         Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
     }


### PR DESCRIPTION
This PR puts the slow image build test after the quicker ones (for quicker feedback), uses `IMAGE_TAG` instead of `IMAGE_NAME` in the test descriptions (as only the tag/jdk changes), and improve the description of the test building an image with custom build args.

Before:
> Describing [jenkins/ssh-agent:nanoserver-ltsc2022-jdk21] image is present
> <...>
> Describing [jenkins/ssh-agent:nanoserver-ltsc2022-jdk21] build args

After:
> Describing [nanoserver-ltsc2022-jdk21] image can be built
> Describing [nanoserver-ltsc2022-jdk21] image can be built with custom build args

Extracted from:
- #581 

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
