### PR TITLE
chore(windows/make.ps1) ensure Pester is only installed as user (instead of system)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -190,14 +190,7 @@ if($target -eq 'test') {
         $mod = Get-InstalledModule -Name Pester -MinimumVersion 5.3.0 -MaximumVersion 5.3.3 -ErrorAction SilentlyContinue
         if($null -eq $mod) {
             Write-Host '= TEST: Pester 5.3.x not found: installing...'
-            $module = 'C:\Program Files\WindowsPowerShell\Modules\Pester'
-            if(Test-Path $module) {
-                takeown /F $module /A /R
-                icacls $module /reset
-                icacls $module /grant Administrators:'F' /inheritance:d /T
-                Remove-Item -Path $module -Recurse -Force -Confirm:$false
-            }
-            Install-Module -Force -Name Pester -MaximumVersion 5.3.3
+            Install-Module -Force -Name Pester -MaximumVersion 5.3.3 -Scope CurrentUser
         }
 
         Import-Module Pester


### PR DESCRIPTION
Caused by https://github.com/jenkins-infra/helpdesk/issues/4939#issuecomment-3798893664

Ref. https://learn.microsoft.com/en-us/powershell/module/powershellget/install-module?view=powershellget-2.x#example-5-install-a-module-only-for-the-current-user