### PR TITLE
chore(windows): no `--parallel` on build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -22,7 +22,7 @@ $ProgressPreference = 'SilentlyContinue' # Disable Progress bar for faster downl
 
 $dockerComposeFile = 'build-windows.yaml'
 $baseDockerCmd = 'docker-compose --file={0}' -f $dockerComposeFile
-$baseDockerBuildCmd = '{0} build --parallel --pull' -f $baseDockerCmd
+$baseDockerBuildCmd = '{0} build --pull' -f $baseDockerCmd
 
 $Repository = 'ssh-agent'
 $Organisation = 'jenkins'


### PR DESCRIPTION
This change removes the `parallel` docker compose argument as it seems it wasn't properly configured since the beginning (no amount specified cf https://docs.docker.com/reference/cli/docker/compose/#configuring-parallelism), and did not result in any gain, but instead seems the cause of Windows builds stucks at the end of the build without any obvious error or cause. (cf multiple releases replayed)

Similar to:
- https://github.com/jenkinsci/docker/pull/2280
- https://github.com/jenkinsci/docker-agents/pull/1179

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
