### PR TITLE
chore(updatecli): add JDK25 manifest

### DIFF
--- a/updatecli/updatecli.d/jdk25.yaml
+++ b/updatecli/updatecli.d/jdk25.yaml
@@ -1,0 +1,72 @@
+---
+name: Bump JDK25 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+  temurin25-binaries:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "adoptium"
+      repository: "temurin25-binaries"
+      token: '{{ requiredEnv .github.token }}'
+      branch: "main"
+
+sources:
+  latestJDK25Version:
+    kind: temurin
+    name: Get the latest Adoptium JDK25 version via the API
+    spec:
+      featureversion: 25
+    transformers:
+      - trimprefix: "jdk-"
+
+# Architectures must match those of the targets in docker-bake.hcl
+conditions:
+  checkTemurinAllReleases:
+    name: Check if the "<latestJDK25Version>" is available for all platforms
+    kind: temurin
+    sourceid: latestJDK25Version
+    spec:
+      featureversion: 25
+      platforms:
+        - alpine-linux/x64
+        - alpine-linux/aarch64
+        - linux/x64
+        - linux/aarch64
+        - linux/ppc64le
+        - linux/s390x
+        - windows/x64
+
+targets:
+  setJDK25VersionDockerBake:
+    name: "Bump JDK25 version in the docker-bake.hcl file"
+    kind: hcl
+    transformers:
+      - replacer:
+          from: "+"
+          to: "_"
+    spec:
+      file: docker-bake.hcl
+      path: variable.JAVA25_VERSION.default
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK25 version to {{ source "latestJDK25Version" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk25


### PR DESCRIPTION
This change adds missing manifest for JDK25.

Follow-up of:
- https://github.com/jenkinsci/docker-ssh-agent/pull/549

### Testing done

<details><summary>updatecli diff --config updatecli/updatecli.d/jdk25.yaml --values updatecli/values.github-action.yaml</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/jdk25.yaml"

SCM repository retrieved: 2


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


######################
# BUMP JDK25 VERSION #
######################

Pipeline ID     : 932f2f152a8db6f3b690de963d39fe4815d817cd16c13784a2076883b3f7721d
Dry Run         : enabled

source: latestJDK25Version
--------------------------

✔ [temurin] found version "jdk-25.0.3+9"
[transformers]
✔ Result correctly transformed from "jdk-25.0.3+9" to "25.0.3+9"

condition: checkTemurinAllReleases
----------------------------------

[temurin] using specific version (`spec.SpecificVersion`) from source value "25.0.3+9". Set `disablesourceinput` to true to avoid this behavior.
✔ (Platform "alpine-linux/x64") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "alpine-linux/aarch64") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "linux/x64") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "linux/aarch64") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "linux/ppc64le") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "linux/s390x") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ (Platform "windows/x64") Found release "jdk-25.0.3+9" which maps specified "25.0.3+9" version.
✔ All releases found.

target: setJDK25VersionDockerBake
---------------------------------

Repository      : github.com/jenkinsci/docker-ssh-agent@master

[transformers]
✔ Result correctly transformed from "25.0.3+9" to "25.0.3_9"
⚠ - changes detected:
        path "variable.JAVA25_VERSION.default" updated from "25_36" to "25.0.3_9" in file "docker-bake.hcl"


ACTIONS
========

---
Pipeline Name   : Bump JDK25 version
Pipeline ID     : 932f2f152a8db6f3b690de963d39fe4815d817cd16c13784a2076883b3f7721d
Dry run         : true
Repository      : github.com/jenkinsci/docker-ssh-agent@master
Action          : Bump JDK25 version to 25.0.3+9
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Bump JDK25 version:
        Source:
                ✔ [latestJDK25Version] Get the latest Adoptium JDK25 version via the API
        Condition:
                ✔ [checkTemurinAllReleases] Check if the "<latestJDK25Version>" is available for all platforms
        Target:
                ⚠ [setJDK25VersionDockerBake] Bump JDK25 version in the docker-bake.hcl file
                      * Repository: https://github.com/jenkinsci/docker-ssh-agent.git (branch: master)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
