### PR TITLE
chore(windows): switch Adoptium installation to ZIP archive instead of MSI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' require
 ## Check if a given image exists in the current manifest docker-bake.hcl
 check_image = make --silent list | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the platform 'linux/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
-bake_base_cli := docker buildx bake --file docker-bake.hcl
+bake_base_cli := docker buildx bake --file docker-bake.hcl --file docker-bake.override.json
 bake_cli := $(bake_base_cli) --load
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Note: you can generate this docker compose file from docker-bake.hcl yourself wi
 # - Convert with yq to the format expected by docker compose
 # - Store the result in the docker compose file
 
-$ docker buildx bake --progress=plain --file=docker-bake.hcl windows --print `
+$ docker buildx bake --progress=plain --file=docker-bake.hcl --file docker-bake.override.json windows --print `
     | yq --prettyPrint '.target[] | del(.output) | {(. | key): {\"image\": .tags[0], \"build\": .}}' | yq '{\"services\": .}' `
     | Out-File -FilePath build-windows.yaml
 ```

--- a/build.ps1
+++ b/build.ps1
@@ -83,20 +83,16 @@ Function Test-CommandExists {
 
 function Test-Image {
     param (
-        $ImageNameAndJavaVersion
+        $ImageName
     )
 
-    # Ex: docker.io/jenkins/ssh-agent:windowsservercore-ltsc2019-jdk21|21.0.3_9
-    $items = $ImageNameAndJavaVersion.Split('|')
-    $imageName = $items[0] -replace 'docker.io/', ''
-    $javaVersion = $items[1]
+    $imageName = $ImageName -replace 'docker.io/', ''
     $imageNameItems = $imageName.Split(':')
     $imageTag = $imageNameItems[1]
 
     Write-Host "= TEST: Testing ${ImageName} image"
 
     $env:IMAGE_NAME = $ImageName
-    $env:JAVA_VERSION = "$javaVersion"
 
     $targetPath = '.\target\{0}' -f $imageTag
     if(Test-Path $targetPath) {
@@ -113,13 +109,12 @@ function Test-Image {
         Write-Host "There were $($TestResults.PassedCount) passed tests in ${ImageName}"
     }
     Remove-Item env:\IMAGE_NAME
-    Remove-Item env:\JAVA_VERSION
 
     return $failed
 }
 
 function Initialize-DockerComposeFile {
-    $baseDockerBakeCmd = 'docker buildx bake --progress=plain --file=docker-bake.hcl'
+    $baseDockerBakeCmd = 'docker buildx bake --progress=plain --file=docker-bake.hcl --file docker-bake.override.json'
 
     $items = $ImageType.Split('-')
     $windowsFlavor = $items[0]
@@ -211,7 +206,7 @@ if($target -eq 'test') {
         $testFailed = $false
         $imageDefinitions = Invoke-Expression "$baseDockerCmd config" | yq --unwrapScalar --output-format json '.services' | ConvertFrom-Json
         foreach ($imageDefinition in $imageDefinitions.PSObject.Properties) {
-            $testFailed = $testFailed -or (Test-Image ('{0}|{1}' -f $imageDefinition.Value.image, $imageDefinition.Value.build.args.JAVA_VERSION))
+            $testFailed = $testFailed -or (Test-Image $imageDefinition.Value.image)
         }
 
         # Fail if any test failures

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -118,7 +118,7 @@ target "nanoserver" {
   context    = "."
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
-    JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
+    JAVA_ZIP_URL          = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     WINDOWS_VERSION_TAG   = windows_version
   }
@@ -143,7 +143,7 @@ target "windowsservercore" {
   context    = "."
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
-    JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
+    JAVA_ZIP_URL          = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     WINDOWS_VERSION_TAG   = windows_version
   }

--- a/docker-bake.override.json
+++ b/docker-bake.override.json
@@ -1,0 +1,15 @@
+{
+  "variable": {
+    "jdk_installer_urls": {
+      "default": {
+        "windows": {
+          "amd64": {
+            "17": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip",
+            "21": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.zip",
+            "25": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -1,9 +1,9 @@
 Import-Module -DisableNameChecking -Force $PSScriptRoot/test_helpers.psm1
 
 $global:IMAGE_NAME = Get-EnvOrDefault 'IMAGE_NAME' '' # Ex: jenkins4eval/ssh-agent:nanoserver-ltsc2019-jdk17
-$global:JAVA_VERSION = Get-EnvOrDefault 'JAVA_VERSION' ''
+$global:JAVA_ZIP_URL = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip'
 
-Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Java $global:JAVA_VERSION"
+Write-Host "= TESTS: Preparing $global:IMAGE_NAME"
 
 $imageItems = $global:IMAGE_NAME.Split(':')
 $global:IMAGE_TAG = $imageItems[1]
@@ -203,7 +203,7 @@ Describe "[$global:IMAGE_TAG] create agent container like docker-plugin with '$g
 
 Describe "[$global:IMAGE_TAG] image can be built" {
     It 'builds image' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_VERSION=${global:JAVA_VERSION}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
     }
 }
@@ -218,7 +218,7 @@ Describe "[$global:IMAGE_TAG] image can be built with custom build args" {
         $TEST_JAW = 'C:/hamster'
         $CUSTOM_IMAGE_NAME = "custom-${IMAGE_NAME}"
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_VERSION=${global:JAVA_VERSION}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"user=$TEST_USER`" --build-arg `"JENKINS_AGENT_WORK=$TEST_JAW`" --tag=$CUSTOM_IMAGE_NAME --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"user=$TEST_USER`" --build-arg `"JENKINS_AGENT_WORK=$TEST_JAW`" --tag=$CUSTOM_IMAGE_NAME --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=$global:CONTAINERNAME --publish-all $CUSTOM_IMAGE_NAME $global:CONTAINERSHELL"

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -29,14 +29,16 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION
-RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
-    $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
-    $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION ; `
-    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  "INSTALLDIR=C:\openjdk-${javaMajorVersion}" -Wait -Passthru ; `
-    $proc.WaitForExit() ; `
-    Remove-Item -Path C:\temp -Recurse | Out-Null
+ARG JAVA_HOME
+ARG JAVA_ZIP_URL
+ARG jdkTemp="C:\jdktemp"
+ARG localArchive="${jdkTemp}\jdk.zip"
+RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
+    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive ; `
+    Expand-Archive -Path $env:localArchive -DestinationPath $env:jdkTemp ; `
+    $expandedDir = Get-ChildItem -Path $env:jdkTemp -Directory | Where-Object { $_.Name -like 'jdk*' } ; `
+    Move-Item -Path $expandedDir.FullName -Destination $env:JAVA_HOME -Force ; `
+    Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 FROM mcr.microsoft.com/powershell:nanoserver-"${TOOLS_WINDOWS_VERSION}" AS pwsh-source
 

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -29,14 +29,16 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION
-RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
-    $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
-    $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION ; `
-    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  "INSTALLDIR=C:\openjdk-${javaMajorVersion}" -Wait -Passthru ; `
-    $proc.WaitForExit() ; `
-    Remove-Item -Path C:\temp -Recurse | Out-Null
+ARG JAVA_HOME
+ARG JAVA_ZIP_URL
+ARG jdkTemp="C:\jdktemp"
+ARG localArchive="${jdkTemp}\jdk.zip"
+RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
+    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive ; `
+    Expand-Archive -Path $env:localArchive -DestinationPath $env:jdkTemp ; `
+    $expandedDir = Get-ChildItem -Path $env:jdkTemp -Directory | Where-Object { $_.Name -like 'jdk*' } ; `
+    Move-Item -Path $expandedDir.FullName -Destination $env:JAVA_HOME -Force ; `
+    Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}"
 


### PR DESCRIPTION
Twin of https://github.com/jenkinsci/docker-agents/pull/1263

This PR aims at fixing the stuck CI checks and cleaning up the Windows JDK installation as the MSI execution is hard to debug and prone to many errors while we only need an OpenJDK directory.

Notes (same as the twin PR): 
- A subsequent PR is needed to track installer URLs (e.g. version bumps)
- No GPG verification (yet)
- No Linux (yet)
