### PR TITLE
tests(linux) spread on many (but smaller) VMs agents and resize parallel bats jobs to a sane default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ def agentSelector(String imageType, retryCounter) {
 
         // Linux
         default:
-            // Need Docker and a LOT of memory for faster builds (due to multi archs)
-            platform = 'docker-highmem'
+            // Need Docker in a VM.
+            platform = 'docker && linux && amd64'
             break
     }
 
@@ -42,7 +42,10 @@ def agentSelector(String imageType, retryCounter) {
 // Specify parallel stages
 def parallelStages = [failFast: false]
 [
-    'linux',
+    'alpine_21',
+    'alpine_25',
+    'debian_21',
+    'debian_25',
     'nanoserver-ltsc2019',
     'nanoserver-ltsc2022',
     'windowsservercore-ltsc2019',
@@ -50,8 +53,8 @@ def parallelStages = [failFast: false]
 ].each { imageType ->
     parallelStages[imageType] = {
         withEnv([
-          "IMAGE_TYPE=${imageType}", 
-          "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}",
+            "IMAGE_TYPE=${imageType}",
+            "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}",
         ]) {
             int retryCounter = 0
             retry(count: 2, conditions: [agent(), nonresumable()]) {
@@ -61,8 +64,8 @@ def parallelStages = [failFast: false]
                 node(resolvedAgentLabel) {
                     timeout(time: 60, unit: 'MINUTES') {
                         checkout scm
-                        if (imageType == "linux") {
-                            stage('Prepare Docker') {
+                        if (isUnix()) {
+                            stage("Prepare Docker on ${resolvedAgentLabel}") {
                                 sh 'make docker-init'
                             }
                         }

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ ifneq (true,$(DISABLE_PARALLEL_TESTS))
 # If the GNU 'parallel' command line is absent, then disable parallel execution
 parallel_cli := $(shell command -v parallel 2>/dev/null)
 ifneq (,$(parallel_cli))
-# If parallel execution is enabled, then set 2 tests per core available for the Docker Engine
-test-%: PARALLEL_JOBS ?= $(shell echo $$(( $(shell docker run --rm alpine grep -c processor /proc/cpuinfo) * 2)))
+# If parallel execution is enabled, we should use all vCPUs available for the Docker Engine minus one (to avoid throttling system while using parallel tests)
+test-%: PARALLEL_JOBS ?= $(shell echo $$(( $(shell docker run --rm alpine grep -c processor /proc/cpuinfo) - 1)))
 test-%: bats_flags += --jobs $(PARALLEL_JOBS)
 endif
 endif

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -114,6 +114,7 @@ function run_through_ssh {
 
 function clean_test_container {
   local agent_container=$1
+  docker logs "${agent_container}" | tail -n 50 || :
   docker kill "${agent_container}" &>/dev/null ||:
   docker rm --force --volumes "${agent_container}" &>/dev/null ||:
 }


### PR DESCRIPTION
Correct flaky tests by fixing parallel tasks at 2 level: increase parallelization of resources (e.g. agents)
and decrease the amount of parallel test jobs on a given VM agent.

- Run different Linux distributions on different agents. Easier to track failures and open the door for conditional PR builds
- Stop using "highmem" agents which are usually facing capacity issues and competing with ATH in ci.jenkins.io
- The amount of parallel tasks was insane: 2 containers per vCPUs. Result was flaky tests due to OOM-killed containers (ration vCPUS/memory too high). Restored to "amount of available vCPUs minus one to get some breath space".
- Print the container logs when cleaning up (so we can diagnose failing tests)