### PR TITLE
chore(nanoserver): install `pwsh` from zip

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -115,7 +115,6 @@ target "nanoserver" {
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
     JAVA_ZIP_URL          = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
-    TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     WINDOWS_VERSION_TAG   = windows_version
   }
   tags = [
@@ -140,7 +139,6 @@ target "windowsservercore" {
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
     JAVA_ZIP_URL          = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
-    TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     WINDOWS_VERSION_TAG   = windows_version
   }
   tags = [
@@ -212,13 +210,4 @@ function "windowsversions" {
   result = (notequal(WINDOWS_VERSION_OVERRIDE, "")
     ? [WINDOWS_VERSION_OVERRIDE]
   : ["ltsc2019", "ltsc2022"])
-}
-
-# Return the Windows version to use as base image for the Windows version passed as parameter
-# There is no mcr.microsoft.com/powershell ltsc2019 base image, using a "1809" instead
-function "toolsversion" {
-  params = [version]
-  result = (equal("ltsc2019", version)
-    ? "1809"
-  : version)
 }

--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -13,11 +13,6 @@ $items = $global:IMAGE_TAG.Split('-')
 $global:JAVAMAJORVERSION = $items[2].Remove(0,3)
 $global:WINDOWSFLAVOR = $items[0]
 $global:WINDOWSVERSIONTAG = $items[1]
-$global:TOOLSWINDOWSVERSION = $items[1]
-# There are no eclipse-temurin:*-ltsc2019 or mcr.microsoft.com/powershell:*-ltsc2019 docker images unfortunately, only "1809" ones
-if ($items[1] -eq 'ltsc2019') {
-    $global:TOOLSWINDOWSVERSION = '1809'
-}
 
 # TODO: make this name unique for concurency
 $global:CONTAINERNAME = 'pester-jenkins-ssh-agent-{0}' -f $global:IMAGE_TAG
@@ -59,6 +54,7 @@ TUwLP4n7pK4J2sCIs6fRD5kEYms4BnddXeRuI2fGZHGH70Ci/Q==
 "@
 
 $global:GITLFSVERSION = '3.7.1'
+$global:PWSHVERSION = '7.3.9'
 
 Cleanup($global:CONTAINERNAME)
 
@@ -112,31 +108,33 @@ Describe "[$global:IMAGE_TAG] checking image metadata" {
     }
 }
 
-Describe "[$global:IMAGE_TAG] image has correct version of java and git-lfs installed and in the PATH" {
+Describe "[$global:IMAGE_TAG] image has expected tools versions installed and in the PATH" {
     BeforeAll {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=`"$global:CONTAINERNAME`" --publish-all `"$global:IMAGE_NAME`" `"$global:PUBLIC_SSH_KEY`""
         $exitCode | Should -Be 0
         Is-ContainerRunning $global:CONTAINERNAME
     }
 
-    It 'has java installed and in the path' {
+    It 'has expected java installed and in the path' {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"if(`$null -eq (Get-Command java.exe -ErrorAction SilentlyContinue)) { exit -1 } else { exit 0 }`""
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`$version = java -version 2>&1 ; Write-Host `$version`""
-        $r = [regex] "^openjdk version `"(?<major>\d+)"
-        $m = $r.Match($stdout)
-        $m | Should -Not -Be $null
-        $m.Groups['major'].ToString() | Should -Be "$global:JAVAMAJORVERSION"
+        $stdout.Trim() | Should -Match "^openjdk version `"$global:JAVAMAJORVERSION"
     }
 
-    It 'has git-lfs (and thus git) installed and in the path' {
+    It 'has expected git-lfs (and thus git) installed and in the path' {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs env`""
         $exitCode | Should -Be 0
-        $r = [regex] "^git-lfs/(?<version>\d+\.\d+\.\d+)"
-        $m = $r.Match($stdout)
-        $m | Should -Not -Be $null
-        $m.Groups['version'].ToString() | Should -Be "$global:GITLFSVERSION"
+        $stdout.Trim() | Should -Match "^git-lfs/$([regex]::Escape($global:GITLFSVERSION))"
+    }
+
+    if ($global:WINDOWSFLAVOR -eq 'nanoserver') {
+        It 'has expected pwsh installed and in the path' {
+            $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`$PSVersionTable.PSVersion.ToString()`""
+            $exitCode | Should -Be 0
+            $stdout.Trim() | Should -Match "^$([regex]::Escape($global:POWERSHELLVERSION))"
+        }
     }
 
     AfterAll {
@@ -151,7 +149,7 @@ Describe "[$global:IMAGE_TAG] create agent container with pubkey as argument" {
         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
     }
 
-    It 'runs commands via ssh' {
+    It 'runs commands via ssh, container with pubkey as argument' {
         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
         $exitCode | Should -Be 0
         $stdout | Should -Match 'f00'
@@ -169,7 +167,7 @@ Describe "[$global:IMAGE_TAG] create agent container with pubkey as envvar" {
         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
     }
 
-    It 'runs commands via ssh' {
+    It 'runs commands via ssh, container with pubkey as envvar' {
         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
         $exitCode | Should -Be 0
         $stdout | Should -Match 'f00'
@@ -190,7 +188,7 @@ Describe "[$global:IMAGE_TAG] create agent container like docker-plugin with '$g
         Is-ContainerRunning $global:CONTAINERNAME | Should -BeTrue
     }
 
-    It 'runs commands via ssh' {
+    It 'runs commands via ssh, container like docker-plugin' {
         $exitCode, $stdout, $stderr = Run-ThruSSH $global:CONTAINERNAME "$global:PRIVATE_SSH_KEY" "$global:CONTAINERSHELL -NoLogo -C `"Write-Host 'f00'`""
         $exitCode | Should -Be 0
         $stdout | Should -Match 'f00'
@@ -203,7 +201,7 @@ Describe "[$global:IMAGE_TAG] create agent container like docker-plugin with '$g
 
 Describe "[$global:IMAGE_TAG] image can be built" {
     It 'builds image' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
     }
 }
@@ -218,7 +216,7 @@ Describe "[$global:IMAGE_TAG] image can be built with custom build args" {
         $TEST_JAW = 'C:/hamster'
         $CUSTOM_IMAGE_NAME = "custom-${IMAGE_NAME}"
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:TOOLSWINDOWSVERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"user=$TEST_USER`" --build-arg `"JENKINS_AGENT_WORK=$TEST_JAW`" --tag=$CUSTOM_IMAGE_NAME --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"user=$TEST_USER`" --build-arg `"JENKINS_AGENT_WORK=$TEST_JAW`" --tag=$CUSTOM_IMAGE_NAME --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name=$global:CONTAINERNAME --publish-all $CUSTOM_IMAGE_NAME $global:CONTAINERSHELL"

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -40,13 +40,13 @@ RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
     Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 ARG PWSH_VERSION=7.3.9
-ARG TMPZIP="$env:TEMP\pwsh.zip"
-ARG PSDIR="C:\pwsh"
-RUN $url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip' -f $env:PWSH_VERSION ; `
-    Invoke-WebRequest -Uri $url -OutFile $env:TMPZIP ; `
-    New-Item -ItemType Directory -Path $env:PSDIR -Force | Out-Null ; `
-    Expand-Archive -Path $env:TMPZIP -DestinationPath $env:PSDIR ; `
-    Remove-Item -Path $env:TMPZIP
+RUN $tmpZip = Join-Path $env:TEMP "pwsh.zip" ; `
+    $psFolder = 'C:\pwsh' ; `
+    $url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip' -f $env:PWSH_VERSION ; `
+    Invoke-WebRequest -Uri $url -OutFile $tmpZip ; `
+    New-Item -ItemType Directory -Path $psFolder -Force | Out-Null ; `
+    Expand-Archive -Path $tmpZip -DestinationPath $psFolder ; `
+    Remove-Item -Path $tmpZip
 
 FROM mcr.microsoft.com/windows/nanoserver:"${WINDOWS_VERSION_TAG}"
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -23,8 +23,7 @@
 #  THE SOFTWARE.
 
 ARG WINDOWS_VERSION_TAG
-ARG TOOLS_WINDOWS_VERSION
-FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
+FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-pwsh
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -40,7 +39,13 @@ RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
     Move-Item -Path $expandedDir.FullName -Destination $env:JAVA_HOME -Force ; `
     Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
-FROM mcr.microsoft.com/powershell:nanoserver-"${TOOLS_WINDOWS_VERSION}" AS pwsh-source
+ARG PWSH_VERSION=7.3.9
+ENV PSTMP="C:\pwsh"
+RUN $url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip' -f $env:PWSH_VERSION ; `
+    Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\pwsh.zip" ; `
+    New-Item -ItemType Directory -Path $env:PSTMP -Force | Out-Null ; `
+    Expand-Archive -Path "$env:TEMP\pwsh.zip" -DestinationPath $env:PSTMP ; `
+    Remove-Item -Path "$env:TEMP\pwsh.zip"
 
 FROM mcr.microsoft.com/windows/nanoserver:"${WINDOWS_VERSION_TAG}"
 
@@ -49,10 +54,10 @@ ENV PSHOME="C:\Program Files\PowerShell"
 ENV PATH="C:\Windows\system32;C:\Windows;${PSHOME};"
 
 # The nanoserver image is nice and small, but we need a couple of things to get SSH working
-COPY --from=jdk-core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
-COPY --from=jdk-core /windows/system32/whoami.exe /windows/system32/whoami.exe
-COPY --from=jdk-core $JAVA_HOME $JAVA_HOME
-COPY --from=pwsh-source $PSHOME $PSHOME
+COPY --from=jdk-pwsh /windows/system32/netapi32.dll /windows/system32/netapi32.dll
+COPY --from=jdk-pwsh /windows/system32/whoami.exe /windows/system32/whoami.exe
+COPY --from=jdk-pwsh $JAVA_HOME $JAVA_HOME
+COPY --from=jdk-pwsh /pwsh $PSHOME
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerAdministrator

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -40,12 +40,13 @@ RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
     Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 ARG PWSH_VERSION=7.3.9
-ENV PSTMP="C:\pwsh"
+ARG TMPZIP="$env:TEMP\pwsh.zip"
+ARG PSDIR="C:\pwsh"
 RUN $url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip' -f $env:PWSH_VERSION ; `
-    Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\pwsh.zip" ; `
-    New-Item -ItemType Directory -Path $env:PSTMP -Force | Out-Null ; `
-    Expand-Archive -Path "$env:TEMP\pwsh.zip" -DestinationPath $env:PSTMP ; `
-    Remove-Item -Path "$env:TEMP\pwsh.zip"
+    Invoke-WebRequest -Uri $url -OutFile $env:TMPZIP ; `
+    New-Item -ItemType Directory -Path $env:PSDIR -Force | Out-Null ; `
+    Expand-Archive -Path $env:TMPZIP -DestinationPath $env:PSDIR ; `
+    Remove-Item -Path $env:TMPZIP
 
 FROM mcr.microsoft.com/windows/nanoserver:"${WINDOWS_VERSION_TAG}"
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -40,13 +40,13 @@ RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
     Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 ARG PWSH_VERSION=7.3.9
-RUN $tmpZip = Join-Path $env:TEMP "pwsh.zip" ; `
-    $psFolder = 'C:\pwsh' ; `
+RUN $zip = Join-Path $env:TEMP "pwsh.zip" ; `
+    $dest = 'C:\pwsh' ; `
     $url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.zip' -f $env:PWSH_VERSION ; `
-    Invoke-WebRequest -Uri $url -OutFile $tmpZip ; `
-    New-Item -ItemType Directory -Path $psFolder -Force | Out-Null ; `
-    Expand-Archive -Path $tmpZip -DestinationPath $psFolder ; `
-    Remove-Item -Path $tmpZip
+    Invoke-WebRequest -Uri $url -OutFile $zip ; `
+    New-Item -ItemType Directory -Path $dest -Force | Out-Null ; `
+    Expand-Archive -Path $zip -DestinationPath $dest ; `
+    Remove-Item -Path $zip
 
 FROM mcr.microsoft.com/windows/nanoserver:"${WINDOWS_VERSION_TAG}"
 

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -23,7 +23,6 @@
 #  THE SOFTWARE.
 
 ARG WINDOWS_VERSION_TAG
-ARG TOOLS_WINDOWS_VERSION
 FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324


### PR DESCRIPTION
This change install `pwsh` from PowerShell release archive instead of copying it from a base image.

Keeping the same version as the one shipped in the current base images, a follow-up PR will add an updatecli manifest to keep it up to date.

Ref:
- #683 

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--

[^1]: teaser hinting at why I spent so many commits to arrive at a proper result: _"[...] and to fix a bug in the entrypoint that appears when bumping to version 7.4 and newer"_

-->

