### PR TITLE
chore(tests/nanoserver): proper `PWSHVERSION` env var name

### DIFF
--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -54,7 +54,7 @@ TUwLP4n7pK4J2sCIs6fRD5kEYms4BnddXeRuI2fGZHGH70Ci/Q==
 "@
 
 $global:GITLFSVERSION = '3.7.1'
-$global:PWSHVERSION = '7.3.9'
+$global:PWSHVERSION = '7.6.4'
 
 Cleanup($global:CONTAINERNAME)
 

--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -133,7 +133,7 @@ Describe "[$global:IMAGE_TAG] image has expected tools versions installed and in
         It 'has expected pwsh installed and in the path' {
             $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`$PSVersionTable.PSVersion.ToString()`""
             $exitCode | Should -Be 0
-            $stdout.Trim() | Should -Match "^$([regex]::Escape($global:POWERSHELLVERSION))"
+            $stdout.Trim() | Should -Match "^$([regex]::Escape($global:PWSHVERSION))"
         }
     }
 

--- a/tests/sshAgent.Tests.ps1
+++ b/tests/sshAgent.Tests.ps1
@@ -54,7 +54,7 @@ TUwLP4n7pK4J2sCIs6fRD5kEYms4BnddXeRuI2fGZHGH70Ci/Q==
 "@
 
 $global:GITLFSVERSION = '3.7.1'
-$global:PWSHVERSION = '7.6.4'
+$global:PWSHVERSION = '7.3.9'
 
 Cleanup($global:CONTAINERNAME)
 


### PR DESCRIPTION
Fixup of:
- #682

<!-- Please describe your pull request here. -->

### Testing done

3d352b85b12bd55c74b2dfba77fbbaebb25095c0, failing as expected: https://ci.jenkins.io/job/Packaging/job/docker-ssh-agent/job/PR-690/2/stages/?selected-node=235
```
19:00:51  Describing [nanoserver-ltsc2019-jdk21] image has expected tools versions installed and in the PATH
19:00:52    [+] has expected java installed and in the path 1.04s
19:00:53    [+] has expected git-lfs (and thus git) installed and in the path 844ms
19:00:54    [-] has expected pwsh installed and in the path 472ms
19:00:54     Expected regular expression '^7\.3\.9' to match '7.6.4', but it did not match.
19:00:54     at $stdout.Trim() | Should -Match "^$([regex]::Escape($global:PWSHVERSION))", Z:\agent\workspace\ackaging_docker-ssh-agent_PR-690\tests\sshAgent.Tests.ps1:136
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
