### PR TITLE
chore(tests/windows): verbose Pester outputs on `Run-Program` helper failure

### DIFF
--- a/tests/test_helpers.psm1
+++ b/tests/test_helpers.psm1
@@ -112,10 +112,10 @@ function Run-Program($cmd, $params) {
     $stdout = $proc.StandardOutput.ReadToEnd()
     $stderr = $proc.StandardError.ReadToEnd()
     $proc.WaitForExit()
-    if(($env:TESTS_DEBUG -eq 'debug') -or ($env:TESTS_DEBUG -eq 'verbose')) {
+    if(($env:TESTS_DEBUG -eq 'debug') -or ($env:TESTS_DEBUG -eq 'verbose') -or ($proc.ExitCode -ne 0)) {
         Write-Host -ForegroundColor DarkBlue "[cmd] $cmd $params"
-        if ($env:TESTS_DEBUG -eq 'verbose') { Write-Host -ForegroundColor DarkGray "[stdout] $stdout" }
-        if($proc.ExitCode -ne 0){
+        if ($env:TESTS_DEBUG -ne 'debug') { Write-Host -ForegroundColor DarkGray "[stdout] $stdout" }
+        if ($proc.ExitCode -ne 0) {
             Write-Host -ForegroundColor DarkRed "[stderr] $stderr"
         }
     }


### PR DESCRIPTION
This change allows to see command, stderr and stdout on Pester test failures.

### Testing done

Before:
> <img width="2151" height="1156" alt="image" src="https://github.com/user-attachments/assets/669bb104-00c6-4181-a889-6d373b4ef328" />

After:
> <img width="2153" height="1159" alt="image" src="https://github.com/user-attachments/assets/86c0b8c8-940b-4082-a7af-3dc75d2082fc" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
