### PR TITLE
chore(Makefile): unhide command calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ TEST_SUITES ?= $(CURDIR)/tests
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
 ## Check if a given image or group exists in the current manifest docker-bake.hcl
 check_image = $(MAKE) --silent list listgroup-linux | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of '$(MAKE) list' or '$(MAKE) listgroup-linux'. Exiting." ; exit 1 ; }
-# check_image = make --silent list | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the platform 'linux/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)
@@ -77,7 +76,7 @@ endif
 
 # Build all targets with the current OS and architecture
 build: check-reqs
-	$(bake_cli) $(shell make --silent list) --set '*.platform=linux/$(ARCH)'
+	$(bake_cli) $(shell $(MAKE) --silent list) --set '*.platform=linux/$(ARCH)'
 
 # Build a specific target with the current OS and architecture
 build-%: check-reqs target show-%
@@ -95,7 +94,7 @@ multiarchbuild-%: check-reqs show-%
 
 # Show all default targets
 show:
-	$(MAKE) --silent show-$(bake_default_target)
+	$(MAKE) show-$(bake_default_target)
 
 # Show a specific target
 show-%:
@@ -107,7 +106,7 @@ showarch-%:
 
 # List tags of all default targets
 tags:
-	$(MAKE) --silent tags-$(bake_default_target)
+	$(MAKE) tags-$(bake_default_target)
 
 # List tags of a specific target
 tags-%:
@@ -115,7 +114,7 @@ tags-%:
 
 # Return the list of targets depending on the current OS and architecture
 list: check-reqs
-	$(MAKE) --silent listarch-$(ARCH)
+	$(MAKE) listarch-$(ARCH)
 
 # Return the list of targets of a specific "target" (can be a docker bake group)
 list-%: check-reqs
@@ -159,7 +158,7 @@ test-%: prepare-test
 # Check that the image exists in the manifest
 	$(call check_image,$*)
 # Ensure that the image is built
-	$(MAKE) --silent build-$*
+	$(MAKE) build-$*
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
 	IMAGE=$* bats/bin/bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
@@ -169,4 +168,4 @@ else
 endif
 
 test: prepare-test
-	$(MAKE) --silent list | while read image; do $(MAKE) --silent "test-$${image}"; done
+	$(MAKE) --silent list | while read image; do $(MAKE) "test-$${image}"; done

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ TEST_SUITES ?= $(CURDIR)/tests
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
 ## Check if a given image or group exists in the current manifest docker-bake.hcl
-check_image = $(MAKE) --silent list listgroup-linux | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of '$(MAKE) list' or '$(MAKE) listgroup-linux'. Exiting." ; exit 1 ; }
+check_image = $(MAKE) --silent listarch-$(ARCH) listgroup-linux | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of '$(MAKE) list' or '$(MAKE) listgroup-linux'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)

--- a/Makefile
+++ b/Makefile
@@ -77,57 +77,57 @@ endif
 
 # Build all targets with the current OS and architecture
 build: check-reqs
-	@$(bake_cli) $(shell make --silent list) --set '*.platform=linux/$(ARCH)'
+	$(bake_cli) $(shell make --silent list) --set '*.platform=linux/$(ARCH)'
 
 # Build a specific target with the current OS and architecture
 build-%: check-reqs target show-%
-	@$(call check_image,$*)
+	$(call check_image,$*)
 	@echo "== building $*"
-	@$(bake_cli) --metadata-file=target/build-result-metadata_$*.json --set '*.platform=$(OS)/$(ARCH)' '$*'
+	$(bake_cli) --metadata-file=target/build-result-metadata_$*.json --set '*.platform=$(OS)/$(ARCH)' '$*'
 
 # Build default bake group corresponding to the current OS but independently of the architecture
 multiarchbuild: check-reqs show-$(OS)
-	@$(bake_base_cli) $(OS)
+	$(bake_base_cli) $(OS)
 
 # Build a specific bake group or target independently of the architecture or the OS
 multiarchbuild-%: check-reqs show-%
-	@$(bake_base_cli) $*
+	$(bake_base_cli) $*
 
 # Show all default targets
 show:
-	@$(MAKE) --silent show-$(bake_default_target)
+	$(MAKE) --silent show-$(bake_default_target)
 
 # Show a specific target
 show-%:
-	@$(bake_base_cli) --progress=quiet --print $* | jq
+	$(bake_base_cli) --progress=quiet --print $* | jq
 
 # Show all targets depending on the architecture
 showarch-%:
-	@$(MAKE) --silent show | jq --arg arch "$(OS)/$*" '.target |= with_entries(select(.value.platforms | index($$arch)))'
+	$(MAKE) --silent show | jq --arg arch "$(OS)/$*" '.target |= with_entries(select(.value.platforms | index($$arch)))'
 
 # List tags of all default targets
 tags:
-	@$(MAKE) --silent tags-$(bake_default_target)
+	$(MAKE) --silent tags-$(bake_default_target)
 
 # List tags of a specific target
 tags-%:
-	@$(MAKE) --silent show-$* | jq -r '.target | to_entries[] | .key as $$name | .value.tags[] | "\(.) (\($$name))"' | LC_ALL=C sort -u
+	$(MAKE) --silent show-$* | jq -r '.target | to_entries[] | .key as $$name | .value.tags[] | "\(.) (\($$name))"' | LC_ALL=C sort -u
 
 # Return the list of targets depending on the current OS and architecture
 list: check-reqs
-	@$(MAKE) --silent listarch-$(ARCH)
+	$(MAKE) --silent listarch-$(ARCH)
 
 # Return the list of targets of a specific "target" (can be a docker bake group)
 list-%: check-reqs
-	@$(MAKE) --silent show-$* | jq -r '.target | keys[]'
+	$(MAKE) --silent show-$* | jq -r '.target | keys[]'
 
 # Return the list of targets depending on the current OS and architecture
 listarch-%: check-reqs
-	@$(MAKE) --silent showarch-$* | jq -r '.target | keys[]'
+	$(MAKE) --silent showarch-$* | jq -r '.target | keys[]'
 
 # Return the list of targets of a specific bake group
 listgroup-%: check-reqs
-	@$(MAKE) --silent show-$* | jq -r '.group | keys[]' | grep -v -e $* -e default
+	$(MAKE) --silent show-$* | jq -r '.group | keys[]' | grep -v -e $* -e default
 
 # Ensure bats exists in the current folder
 bats:
@@ -140,7 +140,7 @@ prepare-test: bats check-reqs
 
 # Publish all linux targets
 publish:
-	@$(bake_base_cli) linux --push
+	$(bake_base_cli) linux --push
 
 ## Define bats options based on environment
 # common flags for all tests
@@ -157,9 +157,9 @@ endif
 endif
 test-%: prepare-test
 # Check that the image exists in the manifest
-	@$(call check_image,$*)
+	$(call check_image,$*)
 # Ensure that the image is built
-	@make --silent build-$*
+	$(MAKE) --silent build-$*
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
 	IMAGE=$* bats/bin/bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
@@ -169,4 +169,4 @@ else
 endif
 
 test: prepare-test
-	@make --silent list | while read image; do make --silent "test-$${image}"; done
+	$(MAKE) --silent list | while read image; do $(MAKE) --silent "test-$${image}"; done


### PR DESCRIPTION
This changes shows which commands are executed from each Makefile target for easier debug if needed.

### Testing done

Before:
```
$ make list
alpine_jdk21
alpine_jdk25
debian_jdk21
debian_jdk25

$ make test-alpine_jdk21
git submodule update --init --recursive
mkdir -p target
{
  "group": {
    "default": {
      "targets": [
        "alpine_jdk21"
      ]
    }
  },
  "target": {
    "alpine_jdk21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.24.1",
        "JAVA_RELEASE": "21"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine3.24",
        "docker.io/jenkins/ssh-agent:latest-alpine3.24",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.24-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.24-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    }
  }
}
== building alpine_jdk21
#0 building with "desktop-linux" instance using docker driver
<...snip...>
```

After:
```
$ make list
/Library/Developer/CommandLineTools/usr/bin/make listarch-arm64
/Library/Developer/CommandLineTools/usr/bin/make --silent showarch-arm64 | jq -r '.target | keys[]'
alpine_jdk21
alpine_jdk25
debian_jdk21
debian_jdk25

$ make test-alpine_jdk21
git submodule update --init --recursive
mkdir -p target
/Library/Developer/CommandLineTools/usr/bin/make list listgroup-linux | grep -w 'alpine_jdk21' >/dev/null 2>&1 || { echo "Error: the image or group 'alpine_jdk21' does not exist in manifest for the current platform 'linux/arm64'. Please check the output of '/Library/Developer/CommandLineTools/usr/bin/make list' or '/Library/Developer/CommandLineTools/usr/bin/make listgroup-linux'. Exiting." ; exit 1 ; }
/Library/Developer/CommandLineTools/usr/bin/make build-alpine_jdk21
docker buildx bake --file docker-bake.hcl --progress=quiet --print alpine_jdk21 | jq
{
  "group": {
    "default": {
      "targets": [
        "alpine_jdk21"
      ]
    }
  },
  "target": {
    "alpine_jdk21": {
      "context": ".",
      "dockerfile": "alpine/Dockerfile",
      "args": {
        "ALPINE_TAG": "3.24.1",
        "JAVA_RELEASE": "21"
      },
      "tags": [
        "docker.io/jenkins/ssh-agent:alpine",
        "docker.io/jenkins/ssh-agent:alpine3.24",
        "docker.io/jenkins/ssh-agent:latest-alpine3.24",
        "docker.io/jenkins/ssh-agent:alpine-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine-jdk21",
        "docker.io/jenkins/ssh-agent:alpine3.24-jdk21",
        "docker.io/jenkins/ssh-agent:latest-alpine3.24-jdk21"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    }
  }
}
== building alpine_jdk21
#0 building with "desktop-linux" instance using docker driver
<...snip...>
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
