### PR TITLE
chore(tests/linux): check host keys without running entrypoint in "image has no pre-existing SSH host keys"

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -56,14 +56,10 @@ docker_run_opts=('--detach' '--publish-all' '--health-cmd=echo | nc -w1 localhos
 }
 
 @test "[${SUT_IMAGE}] image has no pre-existing SSH host keys" {
-  local test_container_name=${AGENT_CONTAINER}-${BASHPID}-ssh-hostkeys
-  clean_test_container "${test_container_name}"
-  docker run --name="${test_container_name}" --name="${test_container_name}" "${docker_run_opts[@]}" "${PUBLIC_SSH_KEY}"
-
-  run docker exec "${test_container_name}" ls -l /etc/ssh/ssh_host*_key*
-  assert_failure
-
-  clean_test_container "${test_container_name}"
+  # Not running the entrypoint which creates host keys
+  run docker run --rm --entrypoint=/bin/sh "${SUT_IMAGE}" -c 'find /etc/ssh -type f -name "ssh_host*_key*" -print'
+  assert_success
+  assert_output ''
 }
 
 @test "[${SUT_IMAGE}] create agent container with pubkey as argument" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -56,7 +56,7 @@ docker_run_opts=('--detach' '--publish-all' '--health-cmd=echo | nc -w1 localhos
 }
 
 @test "[${SUT_IMAGE}] image has no pre-existing SSH host keys" {
-  # Not running the entrypoint which creates host keys
+  # Bypassing entrypoint which creates host keys
   run docker run --rm --entrypoint=/bin/sh "${SUT_IMAGE}" -c 'find /etc/ssh -type f -name "ssh_host*_key*" -print'
   assert_success
   assert_output ''


### PR DESCRIPTION
Closes #715

Amends https://github.com/jenkinsci/docker-ssh-agent/commit/2ab6cbac3742993c8fcc99f0edc3c16945ab32ba (ref: https://www.jenkins.io/security/advisory/2025-04-10)

> [!NOTE]
> I'm not adding any test checking the proper host keys creation by the entrypoint script, left to the reader.


### Testing done

`make test` + CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
